### PR TITLE
Initial GraphQL implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ end
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
+# Ruby GraphQL implememntation [https://github.com/rmosolgo/graphql-ruby]
+gem 'graphql'
+
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'
 
@@ -56,6 +59,9 @@ end
 group :development do
   # Add annotations to model, test, fixtures when run
   gem 'annotate'
+
+  # GraphQL query editor
+  gem "graphiql-rails"
 
   # RuboCop is a Ruby static code analyzer (a.k.a. linter) and code formatter.
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,11 @@ GEM
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    graphiql-rails (1.9.0)
+      railties
+      sprockets-rails
+    graphql (2.1.3)
+      racc (~> 1.4)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -287,6 +292,8 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  graphiql-rails
+  graphql
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  # protect_from_forgery with: :null_session
+
+  def execute
+    variables = prepare_variables(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = {
+      # Query context goes here, for example:
+      # current_user: current_user,
+    }
+    result = TacosSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue StandardError => e
+    raise e unless Rails.env.development?
+    handle_error_in_development(e)
+  end
+
+  private
+
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
+  end
+end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+end

--- a/app/graphql/tacos_schema.rb
+++ b/app/graphql/tacos_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TacosSchema < GraphQL::Schema
-  mutation(Types::MutationType)
   query(Types::QueryType)
 
   # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)

--- a/app/graphql/tacos_schema.rb
+++ b/app/graphql/tacos_schema.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class TacosSchema < GraphQL::Schema
+  mutation(Types::MutationType)
+  query(Types::QueryType)
+
+  # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
+  use GraphQL::Dataloader
+
+  # GraphQL-Ruby calls this when something goes wrong while running a query:
+  def self.type_error(err, context)
+    # if err.is_a?(GraphQL::InvalidNullError)
+    #   # report to your bug tracker here
+    #   return nil
+    # end
+    super
+  end
+
+  # Union and Interface Resolution
+  def self.resolve_type(abstract_type, obj, ctx)
+    # TODO: Implement this method
+    # to return the correct GraphQL object type for `obj`
+    raise(GraphQL::RequiredImplementationMissingError)
+  end
+
+  # Stop validating when it encounters this many errors:
+  validate_max_errors(100)
+
+  # Relay-style Object Identification:
+
+  # Return a string UUID for `object`
+  def self.id_from_object(object, type_definition, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    object.to_gid_param
+  end
+
+  # Given a string UUID, find the object
+  def self.object_from_id(global_id, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    GlobalID.find(global_id)
+  end
+end

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+end

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseConnection < Types::BaseObject
+    # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
+    include GraphQL::Types::Relay::ConnectionBehaviors
+  end
+end

--- a/app/graphql/types/base_edge.rb
+++ b/app/graphql/types/base_edge.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseEdge < Types::BaseObject
+    # add `node` and `cursor` fields, as well as `node_type(...)` override
+    include GraphQL::Types::Relay::EdgeBehaviors
+  end
+end

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseField < GraphQL::Schema::Field
+    argument_class Types::BaseArgument
+  end
+end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+    argument_class Types::BaseArgument
+  end
+end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+
+    field_class Types::BaseField
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseObject < GraphQL::Schema::Object
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+    field_class Types::BaseField
+  end
+end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class MutationType < Types::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,12 +1,4 @@
-# frozen_string_literal: true
-
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
   end
 end

--- a/app/graphql/types/node_type.rb
+++ b/app/graphql/types/node_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  module NodeType
+    include Types::BaseInterface
+    # Add the `id` field
+    include GraphQL::Types::Relay::NodeBehaviors
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryType < Types::BaseObject
+    field :node, Types::NodeType, null: true, description: "Fetches an object given its ID." do
+      argument :id, ID, required: true, description: "ID of the object."
+    end
+
+    def node(id:)
+      context.schema.object_from_id(id, context)
+    end
+
+    field :nodes, [Types::NodeType, null: true], null: true, description: "Fetches a list of objects given a list of IDs." do
+      argument :ids, [ID], required: true, description: "IDs of the objects."
+    end
+
+    def nodes(ids:)
+      ids.map { |id| context.schema.object_from_id(id, context) }
+    end
+
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
+
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,16 +2,17 @@
 
 module Types
   class QueryType < Types::BaseObject
-    field :node, Types::NodeType, null: true, description: "Fetches an object given its ID." do
-      argument :id, ID, required: true, description: "ID of the object."
+    field :node, Types::NodeType, null: true, description: 'Fetches an object given its ID.' do
+      argument :id, ID, required: true, description: 'ID of the object.'
     end
 
     def node(id:)
       context.schema.object_from_id(id, context)
     end
 
-    field :nodes, [Types::NodeType, null: true], null: true, description: "Fetches a list of objects given a list of IDs." do
-      argument :ids, [ID], required: true, description: "IDs of the objects."
+    field :nodes, [Types::NodeType, { null: true }], null: true,
+                                                     description: 'Fetches a list of objects given a list of IDs.' do
+      argument :ids, [ID], required: true, description: 'IDs of the objects.'
     end
 
     def nodes(ids:)
@@ -21,11 +22,15 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    field :log_search_event, SearchEventType, null: false,
+                                              description: 'Log a search and return information about it.' do
+      argument :search_term, String, required: true
+      argument :source_system, String, required: true
+    end
+
+    def log_search_event(search_term:, source_system:)
+      term = Term.create_or_find_by!(phrase: search_term)
+      term.search_events.create!(source: source_system)
     end
   end
 end

--- a/app/graphql/types/search_event_type.rb
+++ b/app/graphql/types/search_event_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class SearchEventType < Types::BaseObject
+    field :id, ID, null: false
+    field :term_id, Integer
+    field :source, String
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+  end
+  post "/graphql", to: "graphql#execute"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class GraphqlControllerTest < ActionDispatch::IntegrationTest
+  test 'search event query returns relevant data' do
+    post '/graphql', params: { query: '{
+                                 logSearchEvent(sourceSystem: "bento", searchTerm: "range life") {
+                                   termId
+                                   source
+                                   createdAt
+                                   updatedAt
+                                 }
+                               }' }
+    assert_equal(200, response.status)
+    json = JSON.parse(response.body)
+    term_id = Term.last.id
+
+    assert_equal 'bento', json['data']['logSearchEvent']['source']
+    assert_equal term_id, json['data']['logSearchEvent']['termId']
+    assert_equal Date.today, json['data']['logSearchEvent']['createdAt'].to_date
+    assert_equal Date.today, json['data']['logSearchEvent']['updatedAt'].to_date
+  end
+
+  test 'search event query creates a new term if one does not exist' do
+    initial_term_count = Term.count
+    post '/graphql', params: { query: '{
+                                 logSearchEvent(sourceSystem: "bento", searchTerm: "range life") {
+                                   termId
+                                   source
+                                   createdAt
+                                   updatedAt
+                                 }
+                               }' }
+    assert_equal(200, response.status)
+    assert_equal Term.count, (initial_term_count + 1)
+    assert_equal 'range life', Term.last.phrase
+  end
+
+  test 'search event query does not create a new term if phrase is already stored' do
+    initial_term_count = Term.count
+    post '/graphql', params: { query: '{
+                                 logSearchEvent(sourceSystem: "timdex", searchTerm: "Super cool search") {
+                                   termId
+                                   source
+                                   createdAt
+                                   updatedAt
+                                 }
+                               }' }
+    assert_equal(200, response.status)
+    assert_equal Term.count, initial_term_count
+  end
+end


### PR DESCRIPTION
### Why these changes are being introduced:

We need a GraphQL interface to record SearchEvents from TACOS
consumers.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-234

### How this addresses that need:

* Adds the GraphQL gem and generates a new install.
* Adds a SearchEvent type and corresponding query field that
returns information about the search event and creates a new
SearchEvent (and Term, if applicable).

### Side effects of this change:

* Removed a couple of generated GraphQL test fields.
* Miscellaneous rubocop fixes.