### PR TITLE
Adds data lookup for detected standard identifiers

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+LINKRESOLVER_BASEURL=https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT
+UNPAYWALL_EMAIL=timdex@mit.edu

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+# Include test env file
+!/.env.test
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'bootsnap', require: false
 # Ruby GraphQL implememntation [https://github.com/rmosolgo/graphql-ruby]
 gem 'graphql'
 
+# HTTP is an easy-to-use client library for making requests from Ruby [https://github.com/httprb/http]
+gem 'http'
+
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'
 
@@ -54,6 +57,9 @@ gem 'tzinfo-data', platforms: %i[windows jruby]
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
+
+  # Allow selective loading of configuration in different contexts (dev/test)
+  gem 'dotenv-rails'
 end
 
 group :development do
@@ -81,4 +87,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,15 +98,27 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.4)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     docile (1.4.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    ffi (1.16.3)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (1.2.1)
       activesupport (>= 6.1)
     graphiql-rails (1.9.0)
@@ -114,6 +126,15 @@ GEM
       sprockets-rails
     graphql (2.1.6)
       racc (~> 1.4)
+    hashdiff (1.0.1)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.3)
@@ -129,6 +150,9 @@ GEM
       activesupport (>= 5.0.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -268,12 +292,20 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
+    vcr (6.2.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -293,8 +325,10 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   graphiql-rails
   graphql
+  http
   importmap-rails
   jbuilder
   puma (>= 5.0)
@@ -310,7 +344,9 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data
+  vcr
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # tacos
+
+## Required Environment Variables
+
+`LINKRESOLVER_BASEURL`: base url for our link resolver. `https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT` is probably the best value unless you are doing something interesting.
+
+`UNPAYWALL_EMAIL`: email address to include in API call as required in their [documentation](https://unpaywall.org/products/api). Your personal email is appropriate for development. Deployed and for tests, use the timdex moira list email.

--- a/app/graphql/types/details_type.rb
+++ b/app/graphql/types/details_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  class DetailsType < Types::BaseObject
+    field :title, String
+    field :authors, [String]
+    field :date, String
+    field :publisher, String
+    field :oa, Boolean
+    field :oa_status, String
+    field :best_oa_location, String
+    field :issns, [String]
+    field :journal_name, String
+    field :doi, String
+    field :link_resolver_url, String
+
+    def issns
+      @object[:journal_issns]&.split(',')
+    end
+
+    def authors
+      @object[:authors]&.split(',')
+    end
+  end
+end

--- a/app/graphql/types/standard_identifiers_type.rb
+++ b/app/graphql/types/standard_identifiers_type.rb
@@ -4,5 +4,21 @@ module Types
   class StandardIdentifiersType < Types::BaseObject
     field :kind, String, null: false
     field :value, String, null: false
+    field :details, DetailsType
+
+    # details does external lookups and should only be run if the fields
+    # have been explicitly requested
+    def details
+      case @object[:kind]
+      when :doi
+        LookupDoi.new.info(@object[:value])
+      when :isbn
+        LookupIsbn.new.info(@object[:value])
+      when :issn
+        LookupIssn.new.info(@object[:value])
+      when :pmid
+        LookupPmid.new.info(@object[:value].split.last)
+      end
+    end
   end
 end

--- a/app/models/lookup_doi.rb
+++ b/app/models/lookup_doi.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class LookupDoi
+  def info(doi)
+    external_data = fetch(doi)
+    return if external_data == 'Error'
+
+    metadata = extract_metadata(external_data)
+    metadata[:doi] = doi
+    metadata[:link_resolver_url] = link_resolver_url(metadata)
+    metadata
+  end
+
+  private
+
+  # NOTE: authors are available as objects within `'z_authors` but is somewhat
+  # complicated so wasn't implemented during this initial work
+  def extract_metadata(external_data)
+    {
+      genre: external_data['genre'],
+      title: external_data['title'],
+      date: external_data['year'],
+      publisher: external_data['publisher'],
+      oa: external_data['is_oa'],
+      oa_status: external_data['oa_status'],
+      best_oa_location: external_data['best_oa_location'],
+      journal_issns: external_data['journal_issns'],
+      journal_name: external_data['journal_name']
+    }
+  end
+
+  def url(doi)
+    "https://api.unpaywall.org/v2/#{doi}?email=#{ENV.fetch('UNPAYWALL_EMAIL')}"
+  end
+
+  def fetch(doi)
+    resp = HTTP.headers(accept: 'application/json').get(url(doi))
+    if resp.status == 200
+      JSON.parse(resp.to_s)
+    else
+      Rails.logger.debug("Fact lookup error. DOI #{doi} detected but unpaywall returned no data or otherwise errored")
+      Rails.logger.debug("URL: #{url(doi)}")
+      'Error'
+    end
+  end
+
+  def link_resolver_url(metadata)
+    "#{ENV.fetch('LINKRESOLVER_BASEURL')}&rft.atitle=#{metadata[:title]}&rft.date=#{metadata[:year]}&rft.genre=#{metadata[:genre]}&rft.jtitle=#{metadata[:journal_name]}&rft_id=info:doi/#{metadata[:doi]}"
+  end
+end

--- a/app/models/lookup_isbn.rb
+++ b/app/models/lookup_isbn.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class LookupIsbn
+  def info(isbn)
+    json = fetch_isbn(isbn)
+    return if json == 'Error'
+
+    {
+      title: json['title'],
+      date: json['publish_date'],
+      publisher: json['publishers'].join(','),
+      authors: fetch_authors(json),
+      link_resolver_url: link_resolver_url(isbn)
+    }
+  end
+
+  def base_url
+    'https://openlibrary.org'
+  end
+
+  def fetch_isbn(isbn)
+    url = [base_url, "/isbn/#{isbn}.json"].join
+    parse_response(url)
+  end
+
+  def fetch_authors(isbn_json)
+    return unless isbn_json['authors']
+
+    authors = isbn_json['authors'].map { |a| a['key'] }
+    author_names = authors.map do |author|
+      url = [base_url, author, '.json'].join
+      json = parse_response(url)
+      json['name']
+    end
+    author_names.join(' ; ')
+  end
+
+  def parse_response(url)
+    resp = HTTP.headers(accept: 'application/json', 'Content-Type': 'application/json').follow.get(url)
+
+    if resp.status == 200
+      JSON.parse(resp.to_s)
+    else
+      Rails.logger.debug('Fact lookup error: openlibrary returned no data')
+      Rails.logger.debug("URL: #{url}")
+      'Error'
+    end
+  end
+
+  def link_resolver_url(isbn)
+    "#{ENV.fetch('LINKRESOLVER_BASEURL')}&rft.isbn=#{isbn}"
+  end
+end

--- a/app/models/lookup_issn.rb
+++ b/app/models/lookup_issn.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# LookupIssn assumes the ISSN being supplied has been validated prior to this Class being used.
+# In this application, we only LookupIssns that have been detected in StandardIdentifiers which performs
+# that validation for us. If extracting this logic to be used elsewhere, it is highly recommended to validate
+# ISSNs before doing an external lookup.
+class LookupIssn
+  def info(issn)
+    json = fetch(issn)
+    return if json == 'Error'
+
+    metadata = extract_metadata(json)
+    metadata[:link_resolver_url] = openurl(issn)
+    metadata
+  end
+
+  def extract_metadata(response)
+    {
+      journal_name: response['message']['title'],
+      publisher: response['message']['publisher'],
+      journal_issns: response['message']['ISSN'].join(',')
+    }
+  end
+
+  def url(issn)
+    "https://api.crossref.org/journals/#{issn}"
+  end
+
+  def fetch(issn)
+    resp = HTTP.headers(accept: 'application/json').get(url(issn))
+    if resp.status == 200
+      JSON.parse(resp.to_s)
+    else
+      Rails.logger.debug("ISSN Lookup error. ISSN #{issn} detected but crossref returned no data")
+      Rails.logger.debug("URL: #{url(issn)}")
+      'Error'
+    end
+  end
+
+  def openurl(issn)
+    "#{ENV.fetch('LINKRESOLVER_BASEURL')}&rft.issn=#{issn}"
+  end
+end

--- a/app/models/lookup_pmid.rb
+++ b/app/models/lookup_pmid.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class LookupPmid
+  def info(pmid)
+    xml = fetch(pmid)
+    return if xml == 'Error'
+
+    metadata = extract_metadata(xml)
+    metadata[:pmid] = pmid
+    metadata[:link_resolver_url] = link_resolver_url(metadata)
+
+    if metadata.reject { |_k, v| v.empty? }.present?
+      metadata
+    else
+      Rails.logger.debug("Fact lookup error. PMID #{pmid} detected but ncbi returned no data")
+      nil
+    end
+  end
+
+  def extract_metadata(xml)
+    {
+      title: xml.xpath('//ArticleTitle').text,
+      journal_name: xml.xpath('//Journal/Title').text,
+      journal_volume: xml.xpath('//Journal/JournalIssue/Volume').text,
+      date: xml.xpath('//Journal/JournalIssue/PubDate/Year').text,
+      doi: xml.xpath('//PubmedData/ArticleIdList/ArticleId[@IdType="doi"]').text
+    }
+  end
+
+  def url(pmid)
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=#{pmid}&retmode=xml"
+  end
+
+  def fetch(pmid)
+    resp = HTTP.headers(accept: 'application/xml').get(url(pmid))
+
+    if resp.status == 200
+      Nokogiri::XML(resp.to_s)
+    else
+      Rails.logger.debug("Fact lookup error. PMID #{pmid} detected but ncbi an error status")
+      Rails.logger.debug("URL: #{url(pmid)}")
+      'Error'
+    end
+  end
+
+  def link_resolver_url(metadata)
+    "#{ENV.fetch('LINKRESOLVER_BASEURL')}&rft.atitle=#{metadata[:title]}&rft.date=#{metadata[:date]}&rft.jtitle=#{metadata[:journal_name]}&rft_id=info:doi/#{metadata[:doi]}"
+  end
+end

--- a/test/models/lookup_doi_test.rb
+++ b/test/models/lookup_doi_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LookupDoiTest < ActiveSupport::TestCase
+  test 'metadata object is returned with expected fields' do
+    VCR.use_cassette('doi 10.1038/d41586-023-03497-2') do
+      metadata = LookupDoi.new.info('10.1038/d41586-023-03497-2')
+
+      expected_keys = %i[genre title date publisher oa oa_status best_oa_location journal_issns
+                         journal_name link_resolver_url]
+      expected_keys.each do |key|
+        assert(metadata.keys.include?(key))
+      end
+    end
+  end
+
+  test 'link resolver url returns expected value' do
+    VCR.use_cassette('doi 10.1038/d41586-023-03497-2') do
+      metadata = LookupDoi.new.info('10.1038/d41586-023-03497-2')
+
+      expected_url = 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT&rft.atitle=Flashy molecules decode a polymer’s lengthening chain&rft.date=&rft.genre=journal-article&rft.jtitle=Nature&rft_id=info:doi/10.1038/d41586-023-03497-2'
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'non 200 responses' do
+    VCR.use_cassette('doi not found') do
+      metadata = LookupDoi.new.info('123456')
+      assert_nil(metadata)
+    end
+  end
+end

--- a/test/models/lookup_isbn_test.rb
+++ b/test/models/lookup_isbn_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LookupIsbnTest < ActiveSupport::TestCase
+  test 'metadata object is returned with expected fields' do
+    VCR.use_cassette('isbn 978-0-08-102133-0') do
+      metadata = LookupIsbn.new.info('978-0-08-102133-0')
+
+      expected_keys = %i[title date publisher authors link_resolver_url]
+      expected_keys.each do |key|
+        assert(metadata.keys.include?(key))
+      end
+    end
+  end
+
+  test 'link resolver url returns expected value' do
+    VCR.use_cassette('isbn 978-0-08-102133-0') do
+      metadata = LookupIsbn.new.info('978-0-08-102133-0')
+
+      expected_url = 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT&rft.isbn=978-0-08-102133-0'
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'non 200 responses' do
+    VCR.use_cassette('isbn not found') do
+      metadata = LookupIsbn.new.info('asdf')
+      assert_nil(metadata)
+    end
+  end
+end

--- a/test/models/lookup_issn_test.rb
+++ b/test/models/lookup_issn_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LookupIssnTest < ActiveSupport::TestCase
+  test 'metadata object is returned with expected fields' do
+    VCR.use_cassette('issn 1078-8956') do
+      metadata = LookupIssn.new.info('1078-8956')
+
+      expected_keys = %i[publisher journal_issns journal_name link_resolver_url]
+      expected_keys.each do |key|
+        assert(metadata.keys.include?(key))
+      end
+    end
+  end
+
+  test 'link resolver url returns expected value' do
+    VCR.use_cassette('issn 1078-8956') do
+      metadata = LookupIssn.new.info('1078-8956')
+
+      expected_url = 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT&rft.issn=1078-8956'
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'non 200 responses' do
+    VCR.use_cassette('issn not found') do
+      metadata = LookupIssn.new.info('asdf')
+      assert_nil(metadata)
+    end
+  end
+end

--- a/test/models/lookup_pmid_test.rb
+++ b/test/models/lookup_pmid_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LookupPmidTest < ActiveSupport::TestCase
+  test 'metadata object is returned with expected fields' do
+    VCR.use_cassette('pmid 37953305') do
+      metadata = LookupPmid.new.info('37953305')
+
+      expected_keys = %i[title date journal_volume doi journal_name link_resolver_url]
+      expected_keys.each do |key|
+        assert(metadata.keys.include?(key))
+      end
+    end
+  end
+
+  test 'link resolver url returns expected value' do
+    VCR.use_cassette('pmid 37953305') do
+      metadata = LookupPmid.new.info('37953305')
+
+      expected_url = "https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT&rft.atitle=Flashy molecules decode a polymer's lengthening chain.&rft.date=2023&rft.jtitle=Nature&rft_id=info:doi/10.1038/d41586-023-03497-2"
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'non 200 responses' do
+    VCR.use_cassette('pmid not found') do
+      metadata = LookupPmid.new.info('asdf')
+      assert_nil(metadata)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 
+VCR.configure do |config|
+  config.cassette_library_dir = 'test/vcr_cassettes'
+  config.hook_into :webmock
+end
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers

--- a/test/vcr_cassettes/doi_10_1038/d41586-023-03497-2.yml
+++ b/test/vcr_cassettes/doi_10_1038/d41586-023-03497-2.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.unpaywall.org/v2/10.1038/d41586-023-03497-2?email=timdex@mit.edu
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.unpaywall.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1700238936&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=hAVtQDLeLgABDWA%2Fyfxl0sXzZLCU4MerIlfAeEp3kAM%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1700238936&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=hAVtQDLeLgABDWA%2Fyfxl0sXzZLCU4MerIlfAeEp3kAM%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - close
+      Server:
+      - gunicorn
+      Date:
+      - Fri, 17 Nov 2023 16:35:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '719'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"doi": "10.1038/d41586-023-03497-2", "doi_url": "https://doi.org/10.1038/d41586-023-03497-2",
+        "title": "Flashy molecules decode a polymer\u2019s lengthening chain", "genre":
+        "journal-article", "is_paratext": false, "published_date": "2023-11-09", "year":
+        2023, "journal_name": "Nature", "journal_issns": "0028-0836,1476-4687", "journal_issn_l":
+        "0028-0836", "journal_is_oa": false, "journal_is_in_doaj": false, "publisher":
+        "Springer Science and Business Media LLC", "is_oa": false, "oa_status": "closed",
+        "has_repository_copy": false, "best_oa_location": null, "first_oa_location":
+        null, "oa_locations": [], "oa_locations_embargoed": [], "updated": "2023-11-14T01:48:08.241432",
+        "data_standard": 2, "z_authors": null}'
+  recorded_at: Fri, 17 Nov 2023 16:35:36 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/doi_not_found.yml
+++ b/test/vcr_cassettes/doi_not_found.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.unpaywall.org/v2/123456?email=timdex@mit.edu
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.unpaywall.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1700240669&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=BtnuqhUFIjq4XdK5GrNboBWBkxLQHGOWd5xwkbPOFCw%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1700240669&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=BtnuqhUFIjq4XdK5GrNboBWBkxLQHGOWd5xwkbPOFCw%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - close
+      Server:
+      - gunicorn
+      Date:
+      - Fri, 17 Nov 2023 17:04:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '164'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "HTTP_status_code": 404,
+            "error": true,
+            "message": "'123456' isn't in Unpaywall. See https://support.unpaywall.org/a/solutions/articles/44001900286"
+        }
+  recorded_at: Fri, 17 Nov 2023 17:04:29 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/isbn_978-0-08-102133-0.yml
+++ b/test/vcr_cassettes/isbn_978-0-08-102133-0.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://openlibrary.org/isbn/978-0-08-102133-0.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - openlibrary.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - nginx/1.18.0 (Ubuntu)
+      Date:
+      - Fri, 17 Nov 2023 17:59:26 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - GET, OPTIONS
+      Access-Control-Max-Age:
+      - '86400'
+      Location:
+      - https://openlibrary.org/books/OL28035297M.json
+      X-Ol-Stats:
+      - '"IB 1 0.025 MC 1 0.000 TT 0 0.026"'
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Fri, 17 Nov 2023 17:59:26 GMT
+- request:
+    method: get
+    uri: https://openlibrary.org/books/OL28035297M.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/5.1.1
+      Host:
+      - openlibrary.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0 (Ubuntu)
+      Date:
+      - Fri, 17 Nov 2023 17:59:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - GET, OPTIONS
+      Access-Control-Max-Age:
+      - '86400'
+      X-Ol-Stats:
+      - '"MC 2 0.001 TT 0 0.003"'
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+    body:
+      encoding: UTF-8
+      string: '{"publishers": ["Butterworth-Heinemann"], "covers": [9415283], "physical_format":
+        "paperback", "full_title": "Orbital Mechanics for Engineering Students", "lc_classifications":
+        ["TL1050"], "latest_revision": 3, "key": "/books/OL28035297M", "authors":
+        [{"key": "/authors/OL7885052A"}], "source_records": ["amazon:008102133X",
+        "bwb:9780081021330"], "title": "Orbital Mechanics for Engineering Students",
+        "notes": {"type": "/type/text", "value": "Source title: Orbital Mechanics
+        for Engineering Students (Aerospace Engineering)"}, "number_of_pages": 792,
+        "created": {"type": "/type/datetime", "value": "2020-05-12T11:06:50.608473"},
+        "isbn_13": ["9780081021330"], "isbn_10": ["008102133X"], "publish_date": "Jul
+        24, 2019", "last_modified": {"type": "/type/datetime", "value": "2020-10-11T22:17:32.783921"},
+        "works": [{"key": "/works/OL20729883W"}], "type": {"key": "/type/edition"},
+        "revision": 3}'
+  recorded_at: Fri, 17 Nov 2023 17:59:27 GMT
+- request:
+    method: get
+    uri: https://openlibrary.org/authors/OL7885052A.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - openlibrary.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0 (Ubuntu)
+      Date:
+      - Fri, 17 Nov 2023 17:59:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - GET, OPTIONS
+      Access-Control-Max-Age:
+      - '86400'
+      X-Ol-Stats:
+      - '"MC 2 0.001 TT 0 0.003"'
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+    body:
+      encoding: UTF-8
+      string: '{"name": "Howard D. Curtis Ph.D.  Purdue University", "created": {"type":
+        "/type/datetime", "value": "2020-05-12T11:06:50.608473"}, "last_modified":
+        {"type": "/type/datetime", "value": "2020-05-12T11:06:50.608473"}, "latest_revision":
+        1, "key": "/authors/OL7885052A", "type": {"key": "/type/author"}, "revision":
+        1}'
+  recorded_at: Fri, 17 Nov 2023 17:59:27 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/isbn_not_found.yml
+++ b/test/vcr_cassettes/isbn_not_found.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://openlibrary.org/isbn/asdf.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - openlibrary.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.18.0 (Ubuntu)
+      Date:
+      - Fri, 17 Nov 2023 17:59:28 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - GET, OPTIONS
+      Access-Control-Max-Age:
+      - '86400'
+      X-Ol-Stats:
+      - '"IB 1 0.003 MC 1 0.000 TT 0 0.004"'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error": "notfound", "key": "/isbn/asdf"}'
+  recorded_at: Fri, 17 Nov 2023 17:59:27 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/issn_1078-8956.yml
+++ b/test/vcr_cassettes/issn_1078-8956.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.crossref.org/journals/1078-8956
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.crossref.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Nov 2023 17:50:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Access-Control-Expose-Headers:
+      - Link
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+        Accept-Ranges, Cache-Control
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - Jetty(9.4.40.v20210413)
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Interval:
+      - 1s
+      X-Api-Pool:
+      - public
+      X-Rate-Limit-Limit:
+      - '50'
+      X-Rate-Limit-Interval:
+      - 1s
+      Permissions-Policy:
+      - interest-cohort=()
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"status":"ok","message-type":"journal","message-version":"1.0.0","message":{"last-status-check-time":1700181899183,"counts":{"current-dois":1650,"backfile-dois":12848,"total-dois":14498},"breakdowns":{"dois-by-issued-year":[[2011,644],[1996,620],[1998,608],[1995,603],[2012,602],[1997,579],[1999,576],[2023,575],[2022,571],[2010,570],[2000,553],[2004,528],[2002,519],[2013,513],[2003,512],[2001,511],[2006,505],[2021,504],[2020,502],[2005,482],[2009,472],[2007,450],[2008,431],[2019,423],[2014,418],[2018,372],[2015,304],[2016,298],[2017,253]]},"publisher":"Springer
+        Science and Business Media LLC","coverage":{"affiliations-current":0.0,"similarity-checking-current":1.0,"descriptions-current":0.0,"ror-ids-current":0.0,"funders-backfile":0.01377646326276463,"licenses-backfile":0.9914383561643836,"funders-current":0.2903030303030303,"affiliations-backfile":0.0,"resource-links-backfile":0.9914383561643836,"orcids-backfile":0.0886519302615193,"update-policies-current":0.8406060606060606,"ror-ids-backfile":0.0,"orcids-current":0.6896969696969697,"similarity-checking-backfile":0.9915161892901619,"references-backfile":0.7176992528019925,"descriptions-backfile":0.0,"award-numbers-backfile":0.01113013698630137,"update-policies-backfile":0.2390255292652553,"licenses-current":1.0,"award-numbers-current":0.1987878787878788,"abstracts-backfile":0.001556662515566625,"resource-links-current":1.0,"abstracts-current":0.1903030303030303,"references-current":0.7290909090909091},"title":"Nature
+        Medicine","subjects":[{"ASJC":1300,"name":"General Biochemistry, Genetics
+        and Molecular Biology"},{"ASJC":2700,"name":"General Medicine"}],"coverage-type":{"all":{"last-status-check-time":1700181899183,"affiliations":0.0,"abstracts":0.02303607145320367,"orcids":0.1570453134698945,"licenses":0.9923442996068694,"references":0.7189461342161528,"funders":0.04524449962066349,"similarity-checking":0.9924132698806813,"award-numbers":0.03248499896544589,"ror-ids":0.0,"update-policies":0.3074694806538382,"resource-links":0.9923442996068694,"descriptions":0.0},"backfile":{"last-status-check-time":1700181899183,"affiliations":0.0,"abstracts":0.001556662515566625,"orcids":0.0886519302615193,"licenses":0.9914383561643836,"references":0.7176992528019925,"funders":0.01377646326276463,"similarity-checking":0.9915161892901619,"award-numbers":0.01113013698630137,"ror-ids":0.0,"update-policies":0.2390255292652553,"resource-links":0.9914383561643836,"descriptions":0.0},"current":{"last-status-check-time":1700181899183,"affiliations":0.0,"abstracts":0.1903030303030303,"orcids":0.6896969696969697,"licenses":1.0,"references":0.7290909090909091,"funders":0.2903030303030303,"similarity-checking":1.0,"award-numbers":0.1987878787878788,"ror-ids":0.0,"update-policies":0.8406060606060606,"resource-links":1.0,"descriptions":0.0}},"flags":{"deposits-abstracts-current":true,"deposits-orcids-current":true,"deposits":true,"deposits-affiliations-backfile":false,"deposits-update-policies-backfile":true,"deposits-similarity-checking-backfile":true,"deposits-award-numbers-current":true,"deposits-resource-links-current":true,"deposits-ror-ids-current":false,"deposits-articles":true,"deposits-affiliations-current":false,"deposits-funders-current":true,"deposits-references-backfile":true,"deposits-ror-ids-backfile":false,"deposits-abstracts-backfile":true,"deposits-licenses-backfile":true,"deposits-award-numbers-backfile":true,"deposits-descriptions-current":false,"deposits-references-current":true,"deposits-resource-links-backfile":true,"deposits-descriptions-backfile":false,"deposits-orcids-backfile":true,"deposits-funders-backfile":true,"deposits-update-policies-current":true,"deposits-similarity-checking-current":true,"deposits-licenses-current":true},"ISSN":["1078-8956","1744-7933"],"issn-type":[{"value":"1078-8956","type":"print"},{"value":"1744-7933","type":"electronic"}]}}'
+  recorded_at: Fri, 17 Nov 2023 17:50:18 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/issn_not_found.yml
+++ b/test/vcr_cassettes/issn_not_found.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.crossref.org/journals/asdf
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.crossref.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 17 Nov 2023 17:54:49 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      Access-Control-Expose-Headers:
+      - Link
+      Access-Control-Allow-Headers:
+      - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+        Accept-Ranges, Cache-Control
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - Jetty(9.4.40.v20210413)
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Interval:
+      - 1s
+      X-Api-Pool:
+      - public
+      X-Rate-Limit-Limit:
+      - '50'
+      X-Rate-Limit-Interval:
+      - 1s
+      Permissions-Policy:
+      - interest-cohort=()
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Resource not found.
+  recorded_at: Fri, 17 Nov 2023 17:54:49 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/pmid_37953305.yml
+++ b/test/vcr_cassettes/pmid_37953305.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=37953305&retmode=xml
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/xml
+      Connection:
+      - close
+      Host:
+      - eutils.ncbi.nlm.nih.gov
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Nov 2023 17:30:05 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Ncbi-Sid:
+      - 030462E715EBA16A_B93BSID
+      Ncbi-Phid:
+      - 322C56F00DDF264500003C3277045652.1.1.m_3
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Remaining:
+      - '2'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=030462E715EBA16A_B93BSID; domain=.nih.gov; path=/; expires=Sun, 17
+        Nov 2024 17:30:06 GMT
+      Vary:
+      - Accept-Encoding
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" ?>
+        <!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2023//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd">
+        <PubmedArticleSet>
+        <PubmedArticle><MedlineCitation Status="Publisher" Owner="NLM" IndexingMethod="Automated"><PMID Version="1">37953305</PMID><DateRevised><Year>2023</Year><Month>11</Month><Day>12</Day></DateRevised><Article PubModel="Print-Electronic"><Journal><ISSN IssnType="Electronic">1476-4687</ISSN><JournalIssue CitedMedium="Internet"><PubDate><Year>2023</Year><Month>Nov</Month><Day>09</Day></PubDate></JournalIssue><Title>Nature</Title><ISOAbbreviation>Nature</ISOAbbreviation></Journal><ArticleTitle>Flashy molecules decode a polymer's lengthening chain.</ArticleTitle><ELocationID EIdType="doi" ValidYN="Y">10.1038/d41586-023-03497-2</ELocationID><Language>eng</Language><PublicationTypeList><PublicationType UI="D016433">News</PublicationType></PublicationTypeList><ArticleDate DateType="Electronic"><Year>2023</Year><Month>11</Month><Day>09</Day></ArticleDate></Article><MedlineJournalInfo><Country>England</Country><MedlineTA>Nature</MedlineTA><NlmUniqueID>0410462</NlmUniqueID><ISSNLinking>0028-0836</ISSNLinking></MedlineJournalInfo><CitationSubset>IM</CitationSubset><KeywordList Owner="NOTNLM"><Keyword MajorTopicYN="N">Chemistry</Keyword></KeywordList></MedlineCitation><PubmedData><History><PubMedPubDate PubStatus="medline"><Year>2023</Year><Month>11</Month><Day>13</Day><Hour>0</Hour><Minute>42</Minute></PubMedPubDate><PubMedPubDate PubStatus="pubmed"><Year>2023</Year><Month>11</Month><Day>13</Day><Hour>0</Hour><Minute>42</Minute></PubMedPubDate><PubMedPubDate PubStatus="entrez"><Year>2023</Year><Month>11</Month><Day>12</Day><Hour>23</Hour><Minute>40</Minute></PubMedPubDate></History><PublicationStatus>aheadofprint</PublicationStatus><ArticleIdList><ArticleId IdType="pubmed">37953305</ArticleId><ArticleId IdType="doi">10.1038/d41586-023-03497-2</ArticleId><ArticleId IdType="pii">10.1038/d41586-023-03497-2</ArticleId></ArticleIdList><ReferenceList><Reference><Citation>Ye, R. et al. Nature Chem. https://doi.org/10.1038/s41557-023-01363-2 (2023).</Citation><ArticleIdList><ArticleId IdType="doi">10.1038/s41557-023-01363-2</ArticleId></ArticleIdList></Reference></ReferenceList></PubmedData></PubmedArticle></PubmedArticleSet>
+  recorded_at: Fri, 17 Nov 2023 17:30:06 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/pmid_not_found.yml
+++ b/test/vcr_cassettes/pmid_not_found.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=asdf&retmode=xml
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/xml
+      Connection:
+      - close
+      Host:
+      - eutils.ncbi.nlm.nih.gov
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 17 Nov 2023 17:34:04 GMT
+      Server:
+      - Finatra
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Ncbi-Sid:
+      - 4F4503D287162994_A463SID
+      Ncbi-Phid:
+      - D0BD49FBABD19BD500004D63451EE40A.1.1.m_1
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Cache-Control:
+      - private
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Remaining:
+      - '2'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Set-Cookie:
+      - ncbi_sid=4F4503D287162994_A463SID; domain=.nih.gov; path=/; expires=Sun, 17
+        Nov 2024 17:34:04 GMT
+      Vary:
+      - Accept-Encoding
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!DOCTYPE eEfetchResult
+        PUBLIC \"-//NLM//DTD efetch 20131226//EN\" \"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20131226/efetch.dtd\">\n<eFetchResult>\n\t<ERROR>ID
+        list is empty! Possibly it has no correct IDs.</ERROR>\n</eFetchResult>\n"
+  recorded_at: Fri, 17 Nov 2023 17:34:04 GMT
+recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/searchevent_10_1038/nphys1170.yml
+++ b/test/vcr_cassettes/searchevent_10_1038/nphys1170.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.unpaywall.org/v2/10.1038/nphys1170?email=timdex@mit.edu
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - api.unpaywall.org
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Report-To:
+      - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1700244429&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2BFYNLpKXL4HZPdB1xG6M8ZbB%2BFCWyaRsIfiUGcOabNg%3D"}]}'
+      Reporting-Endpoints:
+      - heroku-nel=https://nel.heroku.com/reports?ts=1700244429&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2BFYNLpKXL4HZPdB1xG6M8ZbB%2BFCWyaRsIfiUGcOabNg%3D
+      Nel:
+      - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+      Connection:
+      - close
+      Server:
+      - gunicorn
+      Date:
+      - Fri, 17 Nov 2023 18:07:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '733'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS, PUT, DELETE, PATCH
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"doi": "10.1038/nphys1170", "doi_url": "https://doi.org/10.1038/nphys1170",
+        "title": "Measured measurement", "genre": "journal-article", "is_paratext":
+        false, "published_date": "2009-01-01", "year": 2009, "journal_name": "Nature
+        Physics", "journal_issns": "1745-2473,1745-2481", "journal_issn_l": "1745-2473",
+        "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Springer
+        Science and Business Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
+        false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
+        [], "oa_locations_embargoed": [], "updated": "2021-04-01T04:17:18.585258",
+        "data_standard": 2, "z_authors": [{"given": "Markus", "family": "Aspelmeyer",
+        "sequence": "first"}]}'
+  recorded_at: Fri, 17 Nov 2023 18:07:09 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Why are these changes being introduced:

* The ability to provide additional details about what TACOS can detect will allow consuming systems to act on that information. That may mean simply displaying it, or it may mean modifying queries to other systems in more nuanced ways than the original raw search from the user may have led to

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ENGX-244

How does this address that need:

* This brings the Fact lookup models over from TIMDEX UI and modifies them slightly to be more useful to this application.
* A details section has been added under standard_identifiers in graphql that will trigger lookups if identifiers have been detected.
* Only lookups that have matches are run, and only if a user has requested details be provided by requesting fields within the details block

Document any side effects to this change:

dotenv-rails was introduced as a dependency to simplify the test environment configuration.

Any missing configuration documented in the
README will result in exceptions.


