### PR TITLE
Add Heroku config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,6 @@ gem 'rails', '~> 7.1.2'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
-
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem 'turbo-rails'
 
@@ -54,12 +51,20 @@ gem 'tzinfo-data', platforms: %i[windows jruby]
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+group :production do
+  # Use postgres as the database for Active Record
+  gem 'pg'
+end
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
 
   # Allow selective loading of configuration in different contexts (dev/test)
   gem 'dotenv-rails'
+
+  # Use sqlite as the database for Active Record in dev and test
+  gem 'sqlite3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    pg (1.5.4)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -331,6 +332,7 @@ DEPENDENCIES
   http
   importmap-rails
   jbuilder
+  pg
   puma (>= 5.0)
   rails (~> 7.1.2)
   rubocop
@@ -340,7 +342,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   sprockets-rails
-  sqlite3 (~> 1.4)
+  sqlite3
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: bundle exec rails db:migrate
+web: bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+  "name": "timdex",
+  "stack": "heroku-22",
+  "scripts": {},
+  "env": {
+    "LINKRESOLVER_BASEURL": {
+      "required": false
+    },
+    "UNPAYWALL_EMAIL": {
+      "required": false
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "heroku-postgresql"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}


### PR DESCRIPTION
### Why these changes are being introduced:

We need a Procfile and app.json for our Heroku config.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-239

### How this addresses that need:

This adds a Procfile and app.json with the initial settings we'll
need.

### Side effects of this change:

None.