### PR TITLE
Update theme gem and document PLATFORM_NAME variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'importmap-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
-gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.1'
+gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.2'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '>= 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mitlibraries/mitlibraries-theme
-  revision: 93b931b802485f9e35a6878f957b3fd88ae3b294
-  tag: v1.1
+  revision: bcbe5d3de36a92d275085a045c5c4d8f30f33e62
+  tag: v1.2
   specs:
     mitlibraries-theme (1.0.2)
       rails (>= 6, < 8)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # TACOS: Tool for Analyzing and Categorization Of Searchterms
 
-## Required Environment Variables
+## Environment Variables
+
+### Required
 
 `LINKRESOLVER_BASEURL`: base url for our link resolver. `https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT` is probably the best value unless you are doing something interesting.
 
 `UNPAYWALL_EMAIL`: email address to include in API call as required in their [documentation](https://unpaywall.org/products/api). Your personal email is appropriate for development. Deployed and for tests, use the timdex moira list email.
+
+### Optional
+
+`PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes from our theme gem.
 
 ## Documentation
 

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -1,8 +1,10 @@
 <div class="wrap-outer-header-local layout-band">
   <div class="wrap-header-local">
-    <div class="local-identity">
-      <h2 class="title title-site"><a href="/">TACOS</a></h2>
-    </div>
+    <% unless ENV['PLATFORM_NAME'] %>
+      <div class="local-identity">
+        <h2 class="title title-site"><a href="/">TACOS</a></h2>
+      </div>
+    <% end %>
     <div class="wrap-local-nav">
       <div class="wrap-bar">
         <nav class="local-nav" aria-label="Main menu">


### PR DESCRIPTION
### Why these changes are being introduced:

The GDT project added a feature to the theme gem to conditionally include the platform name in the header if the `PLATFORM_NAME` environment variable is supplied.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-124

### How this addresses that need:

This updates the theme gem to the v1.2 tag, which includes the new feature, and documents the PLATFORM_NAME variable.

### Side effects of this change:

None. The app will continue to use the standard header if PLATFORM_NAME is not supplied.
