### PR TITLE
Adds CSV loader for SearchEvents

### DIFF
--- a/lib/tasks/search_event_loader.rake
+++ b/lib/tasks/search_event_loader.rake
@@ -6,9 +6,9 @@ require 'csv'
 namespace :search_events do
   # csv loader can bulk load SearchEvents and Terms.
   #
-  # @note For use in development environments only. Deuplicate search events will be created if the same CSV is loaded
+  # @note For use in development environments only. Duplicate search events will be created if the same CSV is loaded
   #   multiple times.
-  # 
+  #
   # @note the csv should be formated as `term phrase`, `timestamp`. A dataclip is available that can export in this
   #   format.
   # @example

--- a/lib/tasks/search_event_loader.rake
+++ b/lib/tasks/search_event_loader.rake
@@ -4,8 +4,11 @@ require 'csv'
 
 # Loaders can bulk load data
 namespace :search_events do
-  # csv loader can bulk load SearchEvents and Terms
+  # csv loader can bulk load SearchEvents and Terms.
   #
+  # @note For use in development environments only. Deuplicate search events will be created if the same CSV is loaded
+  #   multiple times.
+  # 
   # @note the csv should be formated as `term phrase`, `timestamp`. A dataclip is available that can export in this
   #   format.
   # @example

--- a/lib/tasks/search_event_loader.rake
+++ b/lib/tasks/search_event_loader.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Loaders can bulk load data
+namespace :search_events do
+  # csv loader can bulk load SearchEvents and Terms
+  #
+  # @note the csv should be formated as `term phrase`, `timestamp`. A dataclip is available that can export in this
+  #   format.
+  # @example
+  # bin/rails search_events:csv_loader['local_path_to_file.csv', 'some-source-to-use-for-all-loaded-records']
+  #
+  # @param path [String] local file path to a CSV file to load
+  # @param source [String] source name to load the data under
+  desc 'Load search_events from csv'
+  task :csv_loader, %i[path source] => :environment do |_task, args|
+    raise ArgumentError.new, 'Path is required' unless args.path.present?
+    raise ArgumentError.new, 'Source is required' unless args.source.present?
+
+    Rails.logger.info("Loading data from #{args.path}")
+
+    CSV.foreach(args.path) do |row|
+      term = Term.create_or_find_by!(phrase: row.first)
+      term.search_events.create!(source: args.source, created_at: row.last)
+    end
+  end
+end


### PR DESCRIPTION
https://mitlibraries.atlassian.net/browse/TCO-35

This loader is not meant to be used in production, but instead be a convenience for loading data into development environments to allow for easier development of detection algorithms or reporting.

There is a Dataclip that exports data in the expected format, but it is also easy to generate your own file as it is just `term` and `timestamp` that is expected.

Currently, `source` is provided via CLI but if we find it would be better to include the source in the CSV that would be an easy change to make.
