### PR TITLE
Updates PMID detection regex

### DIFF
--- a/app/models/standard_identifiers.rb
+++ b/app/models/standard_identifiers.rb
@@ -33,7 +33,7 @@ class StandardIdentifiers
     {
       isbn: /\b(ISBN-*(1[03])* *(: ){0,1})*(([0-9Xx][- ]*){13}|([0-9Xx][- ]*){10})\b/,
       issn: /\b[0-9]{4}-[0-9]{3}[0-9xX]\b/,
-      pmid: /\b((pmid|PMID): (\d{7,8}))\b/,
+      pmid: /\b((pmid|PMID):\s?(\d{7,8}))\b/,
       doi: %r{\b10\.(\d+\.*)+/(([^\s.])+\.*)+\b}
     }
   end

--- a/test/models/standard_identifiers_test.rb
+++ b/test/models/standard_identifiers_test.rb
@@ -157,7 +157,7 @@ class StandardIdentifiersTest < ActiveSupport::TestCase
   end
 
   test 'pmid examples' do
-    samples = ['PMID: 35648703', 'pmid: 1234567']
+    samples = ['PMID: 35648703', 'pmid: 1234567', 'PMID:35648703']
 
     samples.each do |pmid|
       actual = StandardIdentifiers.new(pmid).identifiers


### PR DESCRIPTION
NOTE: PMID detection may be entirely silly based on our current bento derived search corpus, but I'd like to keep it in for now as once we expand beyond Bento we may find people search differently.


Why are these changes being introduced:

* The regex was missing PMIDs with no space between the `PMID:` and the indentifier, such as `PMID:35648703`

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-42

How does this address that need:

* Updates regex to allow, but not require, a single whitespace character between `pmid:` and the indentifier

