### PR TITLE
Adds exact journal matches to historical analysis

### DIFF
--- a/db/migrate/20240723202204_add_journal_exact_to_metrics_algorithm.rb
+++ b/db/migrate/20240723202204_add_journal_exact_to_metrics_algorithm.rb
@@ -1,0 +1,5 @@
+class AddJournalExactToMetricsAlgorithm < ActiveRecord::Migration[7.1]
+  def change
+    add_column :metrics_algorithms, :journal_exact, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_143850) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_202204) do
   create_table "detector_journals", force: :cascade do |t|
     t.string "name"
     t.json "additional_info"
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_143850) do
     t.integer "unmatched"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "journal_exact"
   end
 
   create_table "search_events", force: :cascade do |t|

--- a/test/fixtures/search_events.yml
+++ b/test/fixtures/search_events.yml
@@ -31,3 +31,10 @@ current_month_doi:
 current_month_isbn:
   term: isbn_9781319145446
   source: test
+current_month_nature_medicine:
+  term: journal_nature_medicine
+  source: test
+old_month_nature_medicine:
+  term: journal_nature_medicine
+  source: test
+  created_at: <%= 1.year.ago %>

--- a/test/fixtures/terms.yml
+++ b/test/fixtures/terms.yml
@@ -25,3 +25,6 @@ doi:
 
 isbn_9781319145446:
   phrase: 'Sadava, D. E., D. M. Hillis, et al. Life: The Science of Biology. 11th ed. W. H. Freeman, 2016. ISBN: 9781319145446'
+
+journal_nature_medicine:
+  phrase: 'nature medicine'

--- a/test/models/detector/journal_test.rb
+++ b/test/models/detector/journal_test.rb
@@ -44,5 +44,13 @@ module Detector
       actual = Detector::Journal.partial_term_match('words and stuff Nature medicine, 1999')
       assert actual.count == 2
     end
+
+    test 'mixed titles are downcased when saved' do
+      mixed_case = 'ThIs Is A tItLe'
+      actual = Detector::Journal.create(name: mixed_case)
+      actual.reload
+      refute_equal(mixed_case, actual.name)
+      assert_equal(mixed_case.downcase, actual.name)
+    end
   end
 end

--- a/test/models/metrics/algorithms_test.rb
+++ b/test/models/metrics/algorithms_test.rb
@@ -4,15 +4,16 @@
 #
 # Table name: metrics_algorithms
 #
-#  id         :integer          not null, primary key
-#  month      :date
-#  doi        :integer
-#  issn       :integer
-#  isbn       :integer
-#  pmid       :integer
-#  unmatched  :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :integer          not null, primary key
+#  month         :date
+#  doi           :integer
+#  issn          :integer
+#  isbn          :integer
+#  pmid          :integer
+#  unmatched     :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  journal_exact :integer
 #
 require 'test_helper'
 
@@ -36,6 +37,11 @@ class Algorithms < ActiveSupport::TestCase
   test 'pmids counts are included in monthly aggregation' do
     aggregate = Metrics::Algorithms.new.generate(DateTime.now)
     assert aggregate.pmid == 1
+  end
+
+  test 'journal exact counts are included in monthly aggregation' do
+    aggregate = Metrics::Algorithms.new.generate(DateTime.now)
+    assert aggregate.journal_exact == 1
   end
 
   test 'unmatched counts are included are included in monthly aggregation' do
@@ -102,6 +108,11 @@ class Algorithms < ActiveSupport::TestCase
     assert aggregate.pmid == 2
   end
 
+  test 'journal exact counts are included in total aggregation' do
+    aggregate = Metrics::Algorithms.new.generate
+    assert aggregate.journal_exact == 2
+  end
+
   test 'unmatched counts are included are included in total aggregation' do
     aggregate = Metrics::Algorithms.new.generate
     assert aggregate.unmatched == 2
@@ -131,6 +142,11 @@ class Algorithms < ActiveSupport::TestCase
       SearchEvent.create(term: terms(:pmid_38908367), source: 'test')
     end
 
+    journal_exact_count = rand(1...100)
+    journal_exact_count.times do
+      SearchEvent.create(term: terms(:journal_nature_medicine), source: 'test')
+    end
+
     unmatched_expected_count = rand(1...100)
     unmatched_expected_count.times do
       SearchEvent.create(term: terms(:hi), source: 'test')
@@ -142,6 +158,7 @@ class Algorithms < ActiveSupport::TestCase
     assert issn_expected_count == aggregate.issn
     assert isbn_expected_count == aggregate.isbn
     assert pmid_expected_count == aggregate.pmid
+    assert journal_exact_count == aggregate.journal_exact
     assert unmatched_expected_count == aggregate.unmatched
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Understanding our ability to detect search intent over time is core to our ability to know how we are doing

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-54

How does this address that need:

* Adds new field to track exact journal matches to Metrics::Algorithms
* Updates Metrics::Algorithms to run journal exact matches in addition to the existing StandardIdentifer matches. This included a refactor to better support multiple match types.

Document any side effects to this change:

Journal exact matching is not guaranteed to be an indicator of user search intent because Journal names are also common words in many cases. When we build our our validation workflows, we'll be able to understand what percentage of these types of matches are definitely Journals and what percentage is ambiguous. We can likely update our algorithm to drop some of the more ambiguous detections at that point.
