### PR TITLE
Implement authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,10 @@ end
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-# Ruby GraphQL implememntation [https://github.com/rmosolgo/graphql-ruby]
+# Use Devise for authentication
+gem 'devise'
+
+# Ruby GraphQL implementation [https://github.com/rmosolgo/graphql-ruby]
 gem 'graphql'
 
 # HTTP is an easy-to-use client library for making requests from Ruby [https://github.com/httprb/http]
@@ -22,6 +25,11 @@ gem 'importmap-rails'
 gem 'jbuilder'
 
 gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.4'
+
+# Use OmniAuth as Touchstone middleware and include the OIDC strategy and CSRF protection gems
+gem 'omniauth'
+gem 'omniauth_openid_connect'
+gem 'omniauth-rails_csrf_protection'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '>= 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
+  gem 'climate_control'
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,12 +86,16 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    attr_required (1.0.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bigdecimal (3.1.8)
+    bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -115,14 +119,29 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    docile (1.4.1)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    docile (1.4.0)
     domain_name (0.6.20240107)
     dotenv (3.1.2)
     dotenv-rails (3.1.2)
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.1)
+    email_validator (2.2.4)
+      activemodel
     erubi (1.13.0)
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.1.0)
+      net-http
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
@@ -134,6 +153,7 @@ GEM
     graphql (2.3.10)
       base64
     hashdiff (1.1.0)
+    hashie (5.0.0)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -157,6 +177,13 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.2)
+    json-jwt (1.16.6)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     language_server-protocol (3.17.0.3)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
@@ -176,6 +203,8 @@ GEM
     minitest (5.24.1)
     msgpack (1.7.2)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.14)
       date
       net-protocol
@@ -192,6 +221,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.8.0)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
+    openid_connect (2.3.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
+    orm_adapter (0.5.0)
     parallel (1.25.1)
     parser (3.3.4.0)
       ast (~> 2.4.1)
@@ -206,6 +259,16 @@ GEM
     rack (3.1.7)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
+    rack-oauth2 (2.2.1)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -249,7 +312,10 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.2)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
+    rexml (3.3.1)
       strscan
     rubocop (1.65.0)
       json (~> 2.3)
@@ -309,6 +375,11 @@ GEM
     stringex (2.8.6)
     stringio (3.1.1)
     strscan (3.1.0)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     thor (1.3.1)
     tilt (2.4.0)
     timeout (0.4.1)
@@ -319,12 +390,22 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     vcr (6.2.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.23.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -350,12 +431,16 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  devise
   dotenv-rails
   graphql
   http
   importmap-rails
   jbuilder
   mitlibraries-theme!
+  omniauth
+  omniauth-rails_csrf_protection
+  omniauth_openid_connect
   pg
   puma (>= 5.0)
   rack-cors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    climate_control (1.2.0)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -430,6 +431,7 @@ DEPENDENCIES
   annotate
   bootsnap
   capybara
+  climate_control
   debug
   devise
   dotenv-rails

--- a/README.md
+++ b/README.md
@@ -16,24 +16,36 @@ To see a current list of commands, run `make help`.
 
 `UNPAYWALL_EMAIL`: email address to include in API call as required in their [documentation](https://unpaywall.org/products/api). Your personal email is appropriate for development. Deployed and for tests, use the timdex moira list email.
 
-#### Authentication
+### Optional
+
+`PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes
+from our theme gem.
+
+### Authentication
+
+#### Required in all environments
 
 Access to some of the config values below is limited. Please contact someone in the EngX team if you need help locating
 them.
 
 `BASE_URL`: The base url for the app. This is required for Omniauth config.
-`FAKE_AUTH_CONFIG`: Switches Omniauth to developer mode when set to `true`. Fake auth is also enabled whenever the
-app is started in the development environment, or if the app is a PR build (see `HEROKU_APP_NAME` under optional
-variables).
-`OP_HOST`: The OID provider hostname, required for authentication. (Do not include URL prefix.)
-`OP_SECRET_KEY`: The secret key for the OID client.
-`OP_CLIENT_ID`: The identifier for the OID client.
-`OP_ISSUER`: The URL for the OIDC issuer. This can be found in the Touchstone OpenID metadata.
+`OPENID_HOST`: The OID provider hostname, required for authentication. (Do not include URL prefix.)
+`OPENID_SECRET_KEY`: The secret key for the OID client.
+`OPENID_CLIENT_ID`: The identifier for the OID client.
+`OPENID_ISSUER`: The URL for the OIDC issuer. This can be found in the Touchstone OpenID metadata.
 
-### Optional
+#### Required in PR builds
 
-`HEROKU_APP_NAME`: Used by the FakeAuthConfig module to determine whether an app is a PR build.
-`PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes from our theme gem.
+The config below is needed to run Omniauth in developer mode in Heroku review apps. Rather than relying upon a single
+ENV value, we use the `FakeAuthConfig` module to perform additional checks that confirm whether developer mode should
+be enabled. This assures that developer mode is never enabled in staging or production apps.
+
+`FAKE_AUTH_ENABLED`: Switches Omniauth to developer mode when set. If unset, PR builds will attempt to authenticate with
+OIDC, which will fail as their domains are not registered with the provider. (Note: Developer mode is also enabled
+whenever the app is started in the development environment.)
+`HEROKU_APP_NAME`: Used by the FakeAuthConfig module to determine whether an app is a PR build. If this is set along
+with `FAKE_AUTH_ENABLED`, then Omniauth will use Developer mode. Heroku sets this variable automatically for review
+apps; it should never be manually set or overridden in any environment.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Access to some of the config values below is limited. Please contact someone in 
 them.
 
 `BASE_URL`: The base url for the app. This is required for Omniauth config.
+`FAKE_AUTH_CONFIG`: Switches Omniauth to developer mode when set to `true`. Fake auth is also enabled whenever the
+app is started in the development environment, or if the app is a PR build (see `HEROKU_APP_NAME` under optional
+variables).
 `OP_HOST`: The OID provider hostname, required for authentication. (Do not include URL prefix.)
 `OP_SECRET_KEY`: The secret key for the OID client.
 `OP_CLIENT_ID`: The identifier for the OID client.
@@ -29,6 +32,7 @@ them.
 
 ### Optional
 
+`HEROKU_APP_NAME`: Used by the FakeAuthConfig module to determine whether an app is a PR build.
 `PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes from our theme gem.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ To see a current list of commands, run `make help`.
 
 `UNPAYWALL_EMAIL`: email address to include in API call as required in their [documentation](https://unpaywall.org/products/api). Your personal email is appropriate for development. Deployed and for tests, use the timdex moira list email.
 
+#### Authentication
+
+Access to some of the config values below is limited. Please contact someone in the EngX team if you need help locating
+them.
+
+`BASE_URL`: The base url for the app. This is required for Omniauth config.
+`OP_HOST`: The OID provider hostname, required for authentication. (Do not include URL prefix.)
+`OP_SECRET_KEY`: The secret key for the OID client.
+`OP_CLIENT_ID`: The identifier for the OID client.
+`OP_ISSUER`: The URL for the OIDC issuer. This can be found in the Touchstone OpenID metadata.
+
 ### Optional
 
 `PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes from our theme gem.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   helper Mitlibraries::Theme::Engine.helpers
+
+  def new_session_path(_scope)
+    root_path
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,11 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def openid_connect
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+    sign_in_and_redirect @user, event: :authentication
+  end
+
+  # def developer
+  #   @user = User.from_omniauth(request.env['omniauth.auth'])
+  #   sign_in_and_redirect @user, event: :authentication
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,11 +1,20 @@
+# Handles authentication response from Omniauth. See
+# [the Devise docs](https://www.rubydoc.info/gems/devise_token_auth/DeviseTokenAuth/OmniauthCallbacksController) for
+# additional information about this controller.
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def openid_connect
     @user = User.from_omniauth(request.env['omniauth.auth'])
     sign_in_and_redirect @user, event: :authentication
+    flash[:notice] = "Welcome, #{@user.email}!"
   end
 
-  # def developer
-  #   @user = User.from_omniauth(request.env['omniauth.auth'])
-  #   sign_in_and_redirect @user, event: :authentication
-  # end
+  # Developer authentication is used in local dev and PR builds.
+  def developer
+    raise 'Invalid Authentication' unless Rails.configuration.fake_auth_enabled
+
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+    @user.save
+    sign_in_and_redirect @user, event: :authentication
+    flash[:notice] = "Welcome, #{@user.email}!"
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,6 +2,8 @@
 # [the Devise docs](https://www.rubydoc.info/gems/devise_token_auth/DeviseTokenAuth/OmniauthCallbacksController) for
 # additional information about this controller.
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  include FakeAuthConfig
+
   def openid_connect
     @user = User.from_omniauth(request.env['omniauth.auth'])
     sign_in_and_redirect @user, event: :authentication
@@ -10,10 +12,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   # Developer authentication is used in local dev and PR builds.
   def developer
-    raise 'Invalid Authentication' unless Rails.configuration.fake_auth_enabled
+    raise 'Invalid Authentication' unless FakeAuthConfig.fake_auth_enabled?
 
     @user = User.from_omniauth(request.env['omniauth.auth'])
-    @user.save
     sign_in_and_redirect @user, event: :authentication
     flash[:notice] = "Welcome, #{@user.email}!"
   end

--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -1,0 +1,27 @@
+module FakeAuthConfig
+  # Used in an initializer to determine if the application is configured and allowed to use fake authentication.
+  def self.fake_auth_status
+    return true if fake_auth_enabled? && app_name_pattern_match?
+
+    false
+  end
+
+  # Default to fake auth in development unless FAKE_AUTH_ENABLED=false. This allows rake tasks to run without loading
+  # ENV.
+  private_class_method def self.fake_auth_enabled?
+    if Rails.env.development? && ENV['FAKE_AUTH_ENABLED'].nil?
+      true
+    else
+      ENV['FAKE_AUTH_ENABLED'] == 'true'
+    end
+  end
+
+  # Checks if the current app is a Heroku pipeline app, in which case fake_auth should be enabled.
+  # In test ENV we require setting a fake app name to allow for testing of the pattern.
+  private_class_method def self.app_name_pattern_match?
+    return true if Rails.env.development?
+
+    review_app_pattern = /^tacos-api-pipeline-pr-\d+$/
+    review_app_pattern.match(ENV.fetch('HEROKU_APP_NAME', nil)).present?
+  end
+end

--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -1,14 +1,12 @@
 module FakeAuthConfig
   # Used in an initializer to determine if the application is configured and allowed to use fake authentication.
-  def self.fake_auth_status
-    return true if fake_auth_enabled? && app_name_pattern_match?
-
-    false
+  def self.fake_auth_enabled?
+    fake_auth_env? && app_name_pattern_match?
   end
 
   # Default to fake auth in development unless FAKE_AUTH_ENABLED=false. This allows rake tasks to run without loading
   # ENV.
-  private_class_method def self.fake_auth_enabled?
+  private_class_method def self.fake_auth_env?
     if Rails.env.development? && ENV['FAKE_AUTH_ENABLED'].nil?
       true
     else
@@ -16,8 +14,7 @@ module FakeAuthConfig
     end
   end
 
-  # Checks if the current app is a Heroku pipeline app, in which case fake_auth should be enabled.
-  # In test ENV we require setting a fake app name to allow for testing of the pattern.
+  # Check if the app is a PR build. This assures that fake auth is never enabled in staging or prod.
   private_class_method def self.app_name_pattern_match?
     return true if Rails.env.development?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  uid        :string           not null
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class User < ApplicationRecord
+  devise :omniauthable, omniauth_providers: [:openid_connect]
+
+  validates :uid, presence: true
+  validates :email, presence: true
+
+  # Creating a user from Omniauth first requires us to determine whether fake_auth is enabled. If so, we need to
+  # traverse the response hash differently than with OIDC, as developer mode returns metadata in a different structure.
+  # @param auth Hash The authentication response from Omniauth.
+  def self.from_omniauth(auth)
+    User.where(uid: auth.extra.raw_info.preferred_username).first_or_create do |user|
+      user.email = auth.extra.raw_info.email
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,11 @@
 #  updated_at :datetime         not null
 #
 class User < ApplicationRecord
-  devise :omniauthable, omniauth_providers: [:openid_connect]
+  if Rails.configuration.fake_auth_enabled
+    devise :omniauthable, omniauth_providers: [:developer]
+  else
+    devise :omniauthable, omniauth_providers: [:openid_connect]
+  end
 
   validates :uid, presence: true
   validates :email, presence: true
@@ -18,8 +22,16 @@ class User < ApplicationRecord
   # traverse the response hash differently than with OIDC, as developer mode returns metadata in a different structure.
   # @param auth Hash The authentication response from Omniauth.
   def self.from_omniauth(auth)
-    User.where(uid: auth.extra.raw_info.preferred_username).first_or_create do |user|
-      user.email = auth.extra.raw_info.email
+    if Rails.configuration.fake_auth_enabled
+      uid = auth.uid
+      email = auth.info.email
+    else
+      uid = auth.extra.raw_info.preferred_username
+      email = auth.extra.raw_info.email
+    end
+
+    User.where(uid: uid).first_or_create do |user|
+      user.email = email
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,9 @@
 #  updated_at :datetime         not null
 #
 class User < ApplicationRecord
-  if Rails.configuration.fake_auth_enabled
+  include FakeAuthConfig
+
+  if FakeAuthConfig.fake_auth_enabled?
     devise :omniauthable, omniauth_providers: [:developer]
   else
     devise :omniauthable, omniauth_providers: [:openid_connect]
@@ -22,7 +24,7 @@ class User < ApplicationRecord
   # traverse the response hash differently than with OIDC, as developer mode returns metadata in a different structure.
   # @param auth Hash The authentication response from Omniauth.
   def self.from_omniauth(auth)
-    if Rails.configuration.fake_auth_enabled
+    if FakeAuthConfig.fake_auth_enabled?
       uid = auth.uid
       email = auth.info.email
     else
@@ -31,6 +33,7 @@ class User < ApplicationRecord
     end
 
     User.where(uid: uid).first_or_create do |user|
+      user.uid = uid
       user.email = email
     end
   end

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -15,7 +15,7 @@
             <%= button_to("Sign out", destroy_user_session_path, class: 'action-auth', id: "sign_in",
                           method: :delete) %>
           <% else %>
-            <% if Rails.configuration.fake_auth_enabled %>
+            <% if FakeAuthConfig.fake_auth_enabled? %>
               <%= button_to("Sign in", user_developer_omniauth_authorize_path, id: "sign_in", class: 'action-auth',
                             method: :post) %>
             <% else %>

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -10,6 +10,15 @@
         <nav class="local-nav" aria-label="Main menu">
           <%= nav_link_to("Home", root_path) %>
         </nav>
+        <nav class="nav-user" aria-label="User menu">
+          <% if user_signed_in? %>
+            <%= button_to("Sign out", destroy_user_session_path, class: 'action-auth', id: "sign_in",
+                          method: :delete) %>
+          <% else %>
+            <%= button_to("Sign in", user_openid_connect_omniauth_authorize_path, class: 'action-auth', id: "sign_in",
+                          method: :post) %>
+          <% end %>
+        </nav>
       </div>
     </div>
   </div>

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -15,8 +15,13 @@
             <%= button_to("Sign out", destroy_user_session_path, class: 'action-auth', id: "sign_in",
                           method: :delete) %>
           <% else %>
-            <%= button_to("Sign in", user_openid_connect_omniauth_authorize_path, class: 'action-auth', id: "sign_in",
-                          method: :post) %>
+            <% if Rails.configuration.fake_auth_enabled %>
+              <%= button_to("Sign in", user_developer_omniauth_authorize_path, id: "sign_in", class: 'action-auth',
+                            method: :post) %>
+            <% else %>
+              <%= button_to("Sign in", user_openid_connect_omniauth_authorize_path, class: 'action-auth', id: "sign_in",
+                            method: :post) %>
+            <% end %>
           <% end %>
         </nav>
       </div>

--- a/config/initializers/_fake_auth_configuration.rb
+++ b/config/initializers/_fake_auth_configuration.rb
@@ -1,5 +1,0 @@
-# This configuration needs to load before the devise initializer so this value
-# is available when needed.
-
-require "#{Rails.root}/app/models/concerns/fake_auth_config.rb"
-Rails.application.config.fake_auth_enabled = FakeAuthConfig.fake_auth_status

--- a/config/initializers/_fake_auth_configuration.rb
+++ b/config/initializers/_fake_auth_configuration.rb
@@ -1,0 +1,5 @@
+# This configuration needs to load before the devise initializer so this value
+# is available when needed.
+
+require "#{Rails.root}/app/models/concerns/fake_auth_config.rb"
+Rails.application.config.fake_auth_enabled = FakeAuthConfig.fake_auth_status

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,28 @@
+Devise.setup do |config|
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  config.sign_out_via = :delete
+
+  # config.omniauth :developer
+
+  # OIDC configuration
+  config.omniauth :openid_connect, {
+    name: :openid_connect,
+    scope: ['openid', 'email', 'profile'],
+    claims: ['name', 'nickname', 'preferred_username', 'given_name', 'middle_name', 'family_name', 'email', 'profile'],
+    issuer: ENV['OP_ISSUER'],
+    discovery: true,
+    response_type: :code,
+    uid_field: 'kerberos_id',
+    client_options: {
+      host: ENV['OP_HOST'],
+      identifier: ENV['OP_CLIENT_ID'],
+      secret: ENV['OP_CLIENT_SECRET'],
+      redirect_uri: [ENV['BASE_URL'], '/users/auth/openid_connect/callback'].join
+    },
+  }
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,22 +7,24 @@ Devise.setup do |config|
 
   config.sign_out_via = :delete
 
-  # config.omniauth :developer
-
-  # OIDC configuration
-  config.omniauth :openid_connect, {
-    name: :openid_connect,
-    scope: ['openid', 'email', 'profile'],
-    claims: ['name', 'nickname', 'preferred_username', 'given_name', 'middle_name', 'family_name', 'email', 'profile'],
-    issuer: ENV['OP_ISSUER'],
-    discovery: true,
-    response_type: :code,
-    uid_field: 'kerberos_id',
-    client_options: {
-      host: ENV['OP_HOST'],
-      identifier: ENV['OP_CLIENT_ID'],
-      secret: ENV['OP_CLIENT_SECRET'],
-      redirect_uri: [ENV['BASE_URL'], '/users/auth/openid_connect/callback'].join
-    },
-  }
+  if Rails.configuration.fake_auth_enabled
+    config.omniauth :developer
+  else
+    # OIDC configuration
+    config.omniauth :openid_connect, {
+      name: :openid_connect,
+      scope: ['openid', 'email', 'profile'],
+      claims: ['name', 'nickname', 'preferred_username', 'given_name', 'middle_name', 'family_name', 'email', 'profile'],
+      issuer: ENV['OP_ISSUER'],
+      discovery: true,
+      response_type: :code,
+      uid_field: 'kerberos_id',
+      client_options: {
+        host: ENV['OP_HOST'],
+        identifier: ENV['OP_CLIENT_ID'],
+        secret: ENV['OP_CLIENT_SECRET'],
+        redirect_uri: [ENV['BASE_URL'], '/users/auth/openid_connect/callback'].join
+      },
+    }
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,10 +4,11 @@ Devise.setup do |config|
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
   require 'devise/orm/active_record'
+  require "#{Rails.root}/app/models/concerns/fake_auth_config.rb"
 
   config.sign_out_via = :delete
 
-  if Rails.configuration.fake_auth_enabled
+  if FakeAuthConfig.fake_auth_enabled?
     config.omniauth :developer
   else
     # OIDC configuration
@@ -15,14 +16,14 @@ Devise.setup do |config|
       name: :openid_connect,
       scope: ['openid', 'email', 'profile'],
       claims: ['name', 'nickname', 'preferred_username', 'given_name', 'middle_name', 'family_name', 'email', 'profile'],
-      issuer: ENV['OP_ISSUER'],
+      issuer: ENV['OPENID_ISSUER'],
       discovery: true,
       response_type: :code,
       uid_field: 'kerberos_id',
       client_options: {
-        host: ENV['OP_HOST'],
-        identifier: ENV['OP_CLIENT_ID'],
-        secret: ENV['OP_CLIENT_SECRET'],
+        host: ENV['OPENID_HOST'],
+        identifier: ENV['OPENID_CLIENT_ID'],
+        secret: ENV['OPENID_CLIENT_SECRET'],
         redirect_uri: [ENV['BASE_URL'], '/users/auth/openid_connect/callback'].join
       },
     }

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }, only: [:omniauth_callbacks]
+  devise_scope :user do
+    delete '/users/sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+  end
+
   post '/graphql', to: 'graphql#execute'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20240715190838_devise_create_users.rb
+++ b/db/migrate/20240715190838_devise_create_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :uid, null: false
+      t.string :email, null: false
+      t.timestamps
+    end
+
+    add_index :users, :uid, unique: true
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,4 +58,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_202204) do
     t.index ["phrase"], name: "unique_phrase", unique: true
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "uid", null: false
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["uid"], name: "index_users_on_uid", unique: true
+  end
+
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  uid        :string           not null
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+valid:
+  uid: "va@lid.user"
+  email: "va@lid.user"

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class AuthenticationTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  def silence_omniauth
+    previous_logger = OmniAuth.config.logger
+    OmniAuth.config.logger = Logger.new('/dev/null')
+    yield
+  ensure
+    OmniAuth.config.logger = previous_logger
+  end
+
+  test 'accessing callback with bad credentials does not create a new user' do
+    user_count = User.count
+    OmniAuth.config.mock_auth[:openid_connect] = :invalid_credentials
+    silence_omniauth do
+      get '/users/auth/openid_connect/callback'
+      follow_redirect!
+    end
+    assert_response :success
+    assert_equal(user_count, User.count)
+  end
+
+  test 'new users can authenticate' do
+    OmniAuth.config.mock_auth[:openid_connect] =
+      OmniAuth::AuthHash.new(provider: 'openid_connect',
+                             uid: '123545',
+                             extra: { raw_info: { preferred_username: '123545', email: 'test@us.er' } })
+    user_count = User.count
+    get '/users/auth/openid_connect/callback'
+    follow_redirect!
+    assert_response :success
+    assert_equal(user_count + 1, User.count)
+  end
+
+  test 'existing users can authenticate' do
+    user_count = User.count
+    mock_auth(users(:valid))
+    follow_redirect!
+    assert_response :success
+    assert_equal(user_count, User.count)
+  end
+end

--- a/test/models/fake_auth_test.rb
+++ b/test/models/fake_auth_test.rb
@@ -5,16 +5,18 @@ class FakeAuthTest < ActiveSupport::TestCase
 
   test 'fakeauth disabled' do
     ClimateControl.modify(
-      FAKE_AUTH_ENABLED: 'false',
-      HEROKU_APP_NAME: 'thesis-submit-pr-123'
+      FAKE_AUTH_ENABLED: 'false'
     ) do
-      assert_equal(false, FakeAuthConfig.fake_auth_status)
+      assert_equal(false, FakeAuthConfig.fake_auth_enabled?)
     end
+  end
+
+  test 'fakeauth disabled pr apps' do
     ClimateControl.modify(
       FAKE_AUTH_ENABLED: 'false',
-      HEROKU_APP_NAME: 'thesis-dropbox-pr-123'
+      HEROKU_APP_NAME: 'tacos-api-pipeline-pr-1'
     ) do
-      assert_equal(false, FakeAuthConfig.fake_auth_status)
+      assert_equal(false, FakeAuthConfig.fake_auth_enabled?)
     end
   end
 
@@ -23,33 +25,33 @@ class FakeAuthTest < ActiveSupport::TestCase
       FAKE_AUTH_ENABLED: 'true',
       HEROKU_APP_NAME: 'tacos-api-pipeline-pr-1'
     ) do
-      assert_equal(true, FakeAuthConfig.fake_auth_status)
+      assert_equal(true, FakeAuthConfig.fake_auth_enabled?)
     end
     ClimateControl.modify(
       FAKE_AUTH_ENABLED: 'true',
       HEROKU_APP_NAME: 'tacos-api-pipeline-pr-500'
     ) do
-      assert_equal(true, FakeAuthConfig.fake_auth_status)
+      assert_equal(true, FakeAuthConfig.fake_auth_enabled?)
     end
   end
 
   test 'fakeauth enabled no HEROKU_APP_NAME' do
     ClimateControl.modify FAKE_AUTH_ENABLED: 'true' do
-      assert_equal(false, FakeAuthConfig.fake_auth_status)
+      assert_equal(false, FakeAuthConfig.fake_auth_enabled?)
     end
   end
 
   test 'fakeauth enabled production app name' do
     ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
                           HEROKU_APP_NAME: 'tacos-prod' do
-      assert_equal(false, FakeAuthConfig.fake_auth_status)
+      assert_equal(false, FakeAuthConfig.fake_auth_enabled?)
     end
   end
 
   test 'fakeauth enabled staging app name' do
     ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
                           HEROKU_APP_NAME: 'tacos-stage' do
-      assert_equal(false, FakeAuthConfig.fake_auth_status)
+      assert_equal(false, FakeAuthConfig.fake_auth_enabled?)
     end
   end
 end

--- a/test/models/fake_auth_test.rb
+++ b/test/models/fake_auth_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class FakeAuthTest < ActiveSupport::TestCase
+  include FakeAuthConfig
+
+  test 'fakeauth disabled' do
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'false',
+      HEROKU_APP_NAME: 'thesis-submit-pr-123'
+    ) do
+      assert_equal(false, FakeAuthConfig.fake_auth_status)
+    end
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'false',
+      HEROKU_APP_NAME: 'thesis-dropbox-pr-123'
+    ) do
+      assert_equal(false, FakeAuthConfig.fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled PR apps' do
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'true',
+      HEROKU_APP_NAME: 'tacos-api-pipeline-pr-1'
+    ) do
+      assert_equal(true, FakeAuthConfig.fake_auth_status)
+    end
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'true',
+      HEROKU_APP_NAME: 'tacos-api-pipeline-pr-500'
+    ) do
+      assert_equal(true, FakeAuthConfig.fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled no HEROKU_APP_NAME' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true' do
+      assert_equal(false, FakeAuthConfig.fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled production app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
+                          HEROKU_APP_NAME: 'tacos-prod' do
+      assert_equal(false, FakeAuthConfig.fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled staging app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
+                          HEROKU_APP_NAME: 'tacos-stage' do
+      assert_equal(false, FakeAuthConfig.fake_auth_status)
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  uid        :string           not null
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test 'user valid with uid and email' do
+    user = users(:valid)
+    assert user.uid.present?
+    assert user.email.present?
+    assert user.valid?
+  end
+
+  test 'user invalid without uid' do
+    user = users(:valid)
+    assert user.valid?
+
+    user.uid = nil
+    user.save
+    assert_not user.valid?
+  end
+
+  test 'user invalid without email' do
+    user = users(:valid)
+    assert user.valid?
+
+    user.email = nil
+    user.save
+    assert_not user.valid?
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,24 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    def mock_auth(user)
+      OmniAuth.config.mock_auth[:openid_connect] =
+        OmniAuth::AuthHash.new(provider: 'openid_connect',
+                               uid: user.uid,
+                               extra: { raw_info: { preferred_username: user.uid, email: user.email } })
+      get '/users/auth/openid_connect/callback'
+    end
+
+    def auth_setup
+      Rails.application.env_config['devise.mapping'] = Devise.mappings[:user]
+      Rails.application.env_config['omniauth.auth'] =
+        OmniAuth.config.mock_auth[:openid_connect]
+      OmniAuth.config.test_mode = true
+    end
+
+    def auth_teardown
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:openid_connect] = nil
+    end
   end
 end


### PR DESCRIPTION
This adds Touchstone authentication via Devise and Omniauth, along with fake auth for local development and PR builds. The initial auth setup and the fake auth config are in separate commits for ease of review. Please check each commit message for more detailed info on the changesets.

For the time being, I've opted to use Omniauth developer mode for fake auth. We might benefit from using Keycloak in local dev to better simulate a real authentication flow, but setting that proved somewhat complicated and is probably best saved for another time. I've created [a spike ticket](https://mitlibraries.atlassian.net/browse/TCO-59) to investigate further.

To confirm functionality:
* Fake auth logic can be tested in this PR app and locally. It's best to confirm both, because the logic that triggers fake auth is different for each environment. (Local checks for the development environment, whereas PR builds check for the `HEROKU_APP_NAME` env.)
* Prod auth can be tested in staging. I've been doing that by deploying this branch, confirming that I can log in, then redeploying `main`.