### PR TITLE
Add CanCanCan for authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ end
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
+# Use CanCanCan for authorization
+gem 'cancancan'
+
 # Use Devise for authentication
 gem 'devise'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    cancancan (3.6.1)
     capybara (3.40.0)
       addressable
       matrix
@@ -430,6 +431,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bootsnap
+  cancancan
   capybara
   climate_control
   debug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   helper Mitlibraries::Theme::Engine.helpers
 
+  rescue_from CanCan::AccessDenied do
+    redirect_to root_path, alert: 'Not authorized.'
+  end
+
   def new_session_path(_scope)
     root_path
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  # Define abilities for the user here.
+  # See the wiki for details:
+  # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  def initialize(user)
+    return unless user.present?
+    # Rules will go here.
+
+    return unless user.admin?
+    can :manage, :all
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@
 #  email      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  admin      :boolean          default(FALSE)
 #
 class User < ApplicationRecord
   include FakeAuthConfig

--- a/db/migrate/20240805203949_add_admin_to_users.rb
+++ b/db/migrate/20240805203949_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_23_202204) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_05_203949) do
   create_table "detector_journals", force: :cascade do |t|
     t.string "name"
     t.json "additional_info"
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_202204) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,6 +7,7 @@
 #  email      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  admin      :boolean          default(FALSE)
 #
 
 # This model initially had no columns defined. If you add columns to the
@@ -16,3 +17,13 @@
 valid:
   uid: "va@lid.user"
   email: "va@lid.user"
+
+basic:
+  uid: "basic@example.org"
+  email: "basic@example.org"
+  admin: false
+
+admin:
+  uid: "admin@example.org"
+  email: "admin@example.org"
+  admin: true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,8 +7,9 @@
 #  email      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  admin      :boolean          default(FALSE)
 #
-require "test_helper"
+require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   test 'user valid with uid and email' do
@@ -34,5 +35,17 @@ class UserTest < ActiveSupport::TestCase
     user.email = nil
     user.save
     assert_not user.valid?
+  end
+
+  test 'admin user is valid' do
+    user = users(:admin)
+    assert user.admin?
+    assert user.valid?
+  end
+
+  test 'non-admin user is valid' do
+    user = users(:basic)
+    assert_not user.admin?
+    assert user.valid?
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We will need authorization for TACOS, as it will contain a variety of features that should not be avilable to every user.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-31

#### How this addresses that need:

This adds the CanCanCan gem, which [we agreed to use for authorization'](https://github.com/MITLibraries/tacos/blob/main/docs/architecture-decisions/0006-use-cancancan-for-authorization.md). It also introduces a very rudimentary Ability model -- mostly a placeholder until we know what we need -- and a boolean `admin` field to the User model.

It does not implement any rules in the Ability model beyond 'admins can manage anything.'' I debated whether to go even that far, as there's nothing yet to manage.

It's also worth noting that while I was initially opposed to the admin boolean, it does appear to be an idiom within CanCanCan, so I'm comfortable using it here. I think things become more complicated when we combine that pattern with role-based authorization (more on that in side effects, below).

#### Side effects of this change:

Unless we implement [role-based authorization](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/role_based_authorization.md), as we've done in ETD, CanCanCan seems to want us to include all of our rules in the `initialize` method. That feels like it would get out of hand quickly.

We had briefly discussed in a team meeting that we _don't_ want to implement authorization similarly to ETD, with increasing permissions at each role. (Though, that type of cascading is where [CanCanCan excels](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md).) It is also possible to assign multiple roles to a single user, [albeit kludgily](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/role_based_authorization.md#many-roles-per-user).

I do think roles are the way to go here, but we'll want to proceed with caution. As mentioned in the ADR, we may learn early on that CanCanCan is not actually the best authorization gem; finding that we need a dozen or more roles may be one trigger to consider an alternative gem.