### PR TITLE
Adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+Summary of changes (please refer to commit messages for full details)
+
+## Developer
+
+### Ticket(s)
+
+https://mitlibraries.atlassian.net/browse/TCO-###
+
+### Accessibility
+
+- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
+      all issues introduced by these changes have been resolved or opened 
+      as new issues (link to those issues in the Pull Request details above)
+- [ ] There are no accessibility implications to this change
+
+### Documentation
+
+- [ ] Project documentation has been updated, and yard output previewed
+- [ ] No documentation changes are needed
+
+### ENV
+
+- [ ] All new ENV is documented in README.
+- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
+- [ ] ENV has not changed.
+
+### Stakeholders
+
+- [ ] Stakeholder approval has been confirmed
+- [ ] Stakeholder approval is not needed
+
+### Dependencies and migrations
+
+YES | NO dependencies are updated
+
+YES | NO migrations are included
+
+
+## Reviewer
+
+### Code
+
+- [ ] I have confirmed that the code works as intended.
+- [ ] Any CodeClimate issues have been fixed or confirmed as
+added technical debt.
+
+### Documentation
+
+- [ ] The commit message is clear and follows our guidelines
+      (not just this pull request message).
+- [ ] The documentation has been updated or is unnecessary.
+- [ ] New dependencies are appropriate or there were no changes.
+
+### Testing
+
+- [ ] There are appropriate tests covering any new functionality.
+- [ ] No additional test coverage is required.


### PR DESCRIPTION
This adds a PR template file for this application, based on our other Heroku applications. One notable difference is that the Documentation section makes specific reference to checking the documentation built by Yard.

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/TCO-49
* https://mitlibraries.atlassian.net/browse/ENGX-226
