### PR TITLE
Extend Metrics::Algorithms feature to include Detector::SuggestedResource matches

### DIFF
--- a/app/models/detector/suggested_resource.rb
+++ b/app/models/detector/suggested_resource.rb
@@ -23,12 +23,12 @@ module Detector
     before_save :update_fingerprint
 
     def update_fingerprint
-      self.fingerprint = calculate_fingerprint(phrase)
+      self.fingerprint = Detector::SuggestedResource.calculate_fingerprint(phrase)
     end
 
     # This implements the OpenRefine fingerprinting algorithm. See
     # https://openrefine.org/docs/technical-reference/clustering-in-depth#fingerprint
-    def calculate_fingerprint(old_phrase)
+    def self.calculate_fingerprint(old_phrase)
       modified_phrase = old_phrase
       modified_phrase = modified_phrase.strip
       modified_phrase = modified_phrase.downcase
@@ -75,6 +75,10 @@ module Detector
         record = Detector::SuggestedResource.new({ title: line['Title'], url: line['URL'], phrase: line['Phrase'] })
         record.save
       end
+    end
+
+    def self.full_term_match(phrase)
+      SuggestedResource.where(fingerprint: calculate_fingerprint(phrase))
     end
   end
 end

--- a/app/models/metrics/algorithms.rb
+++ b/app/models/metrics/algorithms.rb
@@ -45,6 +45,7 @@ module Metrics
                 end
       Metrics::Algorithms.create(month:, doi: matches[:doi], issn: matches[:issn], isbn: matches[:isbn],
                                  pmid: matches[:pmid], journal_exact: matches[:journal_exact],
+                                 suggested_resource_exact: matches[:suggested_resource_exact],
                                  unmatched: matches[:unmatched])
     end
 
@@ -73,8 +74,9 @@ module Metrics
     def event_matches(event, matches)
       ids = match_standard_identifiers(event, matches)
       journal_exact = process_journals(event, matches)
+      suggested_resource_exact = process_suggested_resources(event, matches)
 
-      matches[:unmatched] += 1 if ids.identifiers.blank? && journal_exact.count.zero?
+      matches[:unmatched] += 1 if ids.identifiers.blank? && journal_exact.count.zero? && suggested_resource_exact.count.zero?
     end
 
     # Checks for StandardIdentifer matches
@@ -106,6 +108,12 @@ module Metrics
       journal_exact = Detector::Journal.full_term_match(event.term.phrase)
       matches[:journal_exact] += 1 if journal_exact.count.positive?
       journal_exact
+    end
+
+    def process_suggested_resources(event, matches)
+      suggested_resource_exact = Detector::SuggestedResource.full_term_match(event.term.phrase)
+      matches[:suggested_resource_exact] += 1 if suggested_resource_exact.count.positive?
+      suggested_resource_exact
     end
   end
 end

--- a/app/models/metrics/algorithms.rb
+++ b/app/models/metrics/algorithms.rb
@@ -110,6 +110,16 @@ module Metrics
       journal_exact
     end
 
+    # Checks for SuggestedResource matches
+    #
+    # @note This only checks for exact matches of the search term, so any extra or missing words will result in no
+    #   match.
+    #
+    # @param event [SearchEvent] an individual search event to check for matches
+    # @param matches [Hash] a Hash that keeps track of how many of each algorithm we match
+    # @return [Array] an array of the one Detector::SuggestedResource record whose fingerprint matches that of the
+    #   search phrase (if one exists). The uniqueness constraint on the fingerprint should mean there is only ever one
+    #   matched record.
     def process_suggested_resources(event, matches)
       suggested_resource_exact = Detector::SuggestedResource.full_term_match(event.term.phrase)
       matches[:suggested_resource_exact] += 1 if suggested_resource_exact.count.positive?

--- a/db/migrate/20240813181057_add_suggested_resource_exact_to_metrics_algorithm.rb
+++ b/db/migrate/20240813181057_add_suggested_resource_exact_to_metrics_algorithm.rb
@@ -1,0 +1,5 @@
+class AddSuggestedResourceExactToMetricsAlgorithm < ActiveRecord::Migration[7.1]
+  def change
+    add_column :metrics_algorithms, :suggested_resource_exact, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_05_203949) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_13_181057) do
   create_table "detector_journals", force: :cascade do |t|
     t.string "name"
     t.json "additional_info"
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_05_203949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "journal_exact"
+    t.integer "suggested_resource_exact"
   end
 
   create_table "search_events", force: :cascade do |t|

--- a/test/fixtures/detector/suggested_resources.yml
+++ b/test/fixtures/detector/suggested_resources.yml
@@ -29,3 +29,9 @@ web_of_knowledge:
   url: https://libguides.mit.edu/webofsci
   phrase: web of knowledge
   fingerprint: knowledge of web
+
+nobel_laureate:
+  title: Professor Moungi Bawendi
+  url: https://news.mit.edu/2023/mit-chemist-moungi-bawendi-shares-nobel-prize-chemistry-1004
+  phrase: moungi bawendi
+  fingerprint: bawendi moungi

--- a/test/fixtures/search_events.yml
+++ b/test/fixtures/search_events.yml
@@ -38,3 +38,10 @@ old_month_nature_medicine:
   term: journal_nature_medicine
   source: test
   created_at: <%= 1.year.ago %>
+suggested_resource_jstor:
+  term: suggested_resource_jstor
+  source: test
+old_suggested_resource_jstor:
+  term: suggested_resource_jstor
+  source: test
+  created_at: <%= 1.year.ago %>

--- a/test/fixtures/terms.yml
+++ b/test/fixtures/terms.yml
@@ -28,3 +28,6 @@ isbn_9781319145446:
 
 journal_nature_medicine:
   phrase: 'nature medicine'
+
+suggested_resource_jstor:
+  phrase: 'jstor'

--- a/test/models/detector/suggested_resource_test.rb
+++ b/test/models/detector/suggested_resource_test.rb
@@ -125,5 +125,31 @@ module Detector
 
       assert_equal 'delta gamma', resource.fingerprint
     end
+
+    test 'fingerprint matches on search term' do
+      expected = detector_suggested_resources('jstor')
+      actual = Detector::SuggestedResource.full_term_match('jstor')
+
+      assert_equal 1, actual.count
+      assert_equal expected, actual.first
+    end
+
+    test 'fingerprint matches on any word order or punctuation' do
+      expected = detector_suggested_resources('nobel_laureate')
+      actual_one = Detector::SuggestedResource.full_term_match('Moungi Bawendi')
+      actual_two = Detector::SuggestedResource.full_term_match('Bawendi, Moungi')
+
+      assert_equal 1, actual_one.count
+      assert_equal expected, actual_one.first
+      assert_equal actual_one.first, actual_two.first
+    end
+
+    test 'partial fingerprint matches do not count' do
+      actual_partial = Detector::SuggestedResource.full_term_match('science web')
+      actual_extra = Detector::SuggestedResource.full_term_match('the web of science')
+
+      assert_predicate actual_partial.count, :zero?
+      assert_predicate actual_extra.count, :zero?
+    end
   end
 end

--- a/test/models/metrics/algorithms_test.rb
+++ b/test/models/metrics/algorithms_test.rb
@@ -49,6 +49,12 @@ class Algorithms < ActiveSupport::TestCase
     assert_equal 1, aggregate.journal_exact
   end
 
+  test 'suggested_resource exact counts are included in monthly aggregation' do
+    aggregate = Metrics::Algorithms.new.generate(DateTime.now)
+
+    assert_equal 1, aggregate.suggested_resource_exact
+  end
+
   test 'unmatched counts are included are included in monthly aggregation' do
     aggregate = Metrics::Algorithms.new.generate(DateTime.now)
 
@@ -124,6 +130,12 @@ class Algorithms < ActiveSupport::TestCase
     assert_equal 2, aggregate.journal_exact
   end
 
+  test 'suggested_resource exact counts are included in total aggregation' do
+    aggregate = Metrics::Algorithms.new.generate
+
+    assert_equal 2, aggregate.suggested_resource_exact
+  end
+
   test 'unmatched counts are included are included in total aggregation' do
     aggregate = Metrics::Algorithms.new.generate
 
@@ -159,6 +171,11 @@ class Algorithms < ActiveSupport::TestCase
       SearchEvent.create(term: terms(:journal_nature_medicine), source: 'test')
     end
 
+    suggested_resource_exact_count = rand(1...100)
+    suggested_resource_exact_count.times do
+      SearchEvent.create(term: terms(:suggested_resource_jstor), source: 'test')
+    end
+
     unmatched_expected_count = rand(1...100)
     unmatched_expected_count.times do
       SearchEvent.create(term: terms(:hi), source: 'test')
@@ -171,6 +188,7 @@ class Algorithms < ActiveSupport::TestCase
     assert_equal isbn_expected_count, aggregate.isbn
     assert_equal pmid_expected_count, aggregate.pmid
     assert_equal journal_exact_count, aggregate.journal_exact
+    assert_equal suggested_resource_exact_count, aggregate.suggested_resource_exact
     assert_equal unmatched_expected_count, aggregate.unmatched
   end
 end


### PR DESCRIPTION
This extends the `Metrics::Algorithms` model which generates historical records of the application's performance to include matches on the SuggestedResources records that have been added recently. A part of this work is that the `Detector::SuggestedResource` model now gets a `full_term_match` method, which is the crucial link to allow the model to do anything about search traffic.

Along the way the `calculate_fingerprint` method becomes a class method, rather than an instance method. It is still part of the SuggestedResource model, and not in a helper.

Much of this approach has been copied from the Journal title matching work - which seems like a reasonable starting point, both because the uses are similar and because consistent approaches in the app feels like Doing This Right.

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-25

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

YES migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
