### PR TITLE
Upgrade heroku stack to 24

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "timdex",
-  "stack": "heroku-22",
+  "name": "tacos",
+  "stack": "heroku-24",
   "scripts": {},
   "env": {
     "LINKRESOLVER_BASEURL": {


### PR DESCRIPTION
Bumps heroku stack from 22 to 24. I've tested the build process and GraphQL playground and haven't noticed any issues.

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-47

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

YES dependencies are updated (sort of -- Heroku stack)

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
