### PR TITLE
Test for searches with multiple detections

### DIFF
--- a/test/fixtures/terms.yml
+++ b/test/fixtures/terms.yml
@@ -31,3 +31,6 @@ journal_nature_medicine:
 
 suggested_resource_jstor:
   phrase: 'jstor'
+
+multiple_detections:
+  phrase: 'Environmental and Health Impacts of Air Pollution: A Review. Frontiers in Public Health. PMID: 32154200. DOI: 10.3389/fpubh.2020.00014'

--- a/test/models/metrics/algorithms_test.rb
+++ b/test/models/metrics/algorithms_test.rb
@@ -61,6 +61,18 @@ class Algorithms < ActiveSupport::TestCase
     assert_equal 2, aggregate.unmatched
   end
 
+  test 'searches with multiple patterns are accounted for correctly' do
+    # Drop all search events to ensure the report has only what we care about.
+    SearchEvent.delete_all
+
+    SearchEvent.create(term: terms(:multiple_detections), source: 'test')
+
+    aggregate = Metrics::Algorithms.new.generate(DateTime.now)
+
+    assert_equal 1, aggregate.doi
+    assert_equal 1, aggregate.pmid
+  end
+
   test 'creating lots of searchevents leads to correct data for monthly' do
     # drop all searchevents to make math easier and minimize fragility over time as more fixtures are created
     SearchEvent.delete_all


### PR DESCRIPTION
## Developer

#### Why are these changes being introduced:

Some of our search traffic may meet conditions of multiple detections. We need our reports to correctly count these events in all relevant categories.

#### How does this address that need:

This starts by creating a single term fixture that should trigger more than one detector - a citation which includes both a DOI and PubMedID for an article.

A new test is also created, which generates a report based only on a search for this term, which asserts that two different counters should have non-zero numbers.

#### Side effects

It is a bit awkward to have too many tests that start by deleting existing records from our fixtures - but we're not yet at the point where we'd need something like a factory. We'll talk about that at some point if the need more clearly arises.

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-43

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
