### PR TITLE
Add GraphQL for Detector::SuggestedResource

### DIFF
--- a/app/graphql/types/detectors_type.rb
+++ b/app/graphql/types/detectors_type.rb
@@ -6,6 +6,7 @@ module Types
 
     field :journals, [Types::JournalsType], description: 'Information about journals detected in the search term'
     field :standard_identifiers, [Types::StandardIdentifiersType], description: 'Currently supported: ISBN, ISSN, PMID, DOI'
+    field :suggested_resources, [Types::SuggestedResourcesType], description: 'Suggested resources detected in the search term'
 
     def standard_identifiers
       Detector::StandardIdentifiers.new(@object).identifiers.map do |identifier|
@@ -16,6 +17,12 @@ module Types
     def journals
       Detector::Journal.full_term_match(@object).map do |journal|
         { title: journal.name, additional_info: journal.additional_info }
+      end
+    end
+
+    def suggested_resources
+      Detector::SuggestedResource.full_term_match(@object).map do |suggested_resource|
+        { title: suggested_resource.title, url: suggested_resource.url }
       end
     end
   end

--- a/app/graphql/types/suggested_resources_type.rb
+++ b/app/graphql/types/suggested_resources_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class SuggestedResourcesType < Types::BaseObject
+    description 'A detector for any suggested resources associated with a search term'
+
+    field :title, String, null: false, description: 'The title or name of the suggested resource'
+    field :url, String, null: false, description: 'The URL to the suggested resource'
+  end
+end

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -91,6 +91,26 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
                  json['data']['logSearchEvent']['detectors']['journals'].first['additionalInfo'])
   end
 
+  test 'search event query can return detected suggested resources' do
+    post '/graphql', params: { query: '{
+                                 logSearchEvent(sourceSystem: "timdex", searchTerm: "web of science") {
+                                   detectors {
+                                     suggestedResources {
+                                       title
+                                       url
+                                     }
+                                   }
+                                 }
+                               }' }
+
+    json = response.parsed_body
+
+    assert_equal 'Web of Science',
+                 json['data']['logSearchEvent']['detectors']['suggestedResources'].first['title']
+    assert_equal 'https://libguides.mit.edu/webofsci',
+                 json['data']['logSearchEvent']['detectors']['suggestedResources'].first['url']
+  end
+
   test 'search event query can return phrase from logged term' do
     post '/graphql', params: { query: '{
                                  logSearchEvent(sourceSystem: "timdex", searchTerm: "10.1038/nphys1170") {


### PR DESCRIPTION
## Why these changes are being introduced:

We have a `SuggestedResource` detector that is not yet modeled in our GraphQL.

## Relevant ticket(s):

* [TCO-24](https://mitlibraries.atlassian.net/browse/TCO-24)

### How this addresses that need:

This adds a `SuggestedResourcesType` as a field on `DetectorsType`.

## Side effects of this change:

None.

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-###

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed **(GraphQL descriptions added)**
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.


[TCO-24]: https://mitlibraries.atlassian.net/browse/TCO-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ