### PR TITLE
Add temporary url_loader for search events

### DIFF
--- a/lib/tasks/search_event_loader.rake
+++ b/lib/tasks/search_event_loader.rake
@@ -14,6 +14,9 @@ namespace :search_events do
   # @example
   # bin/rails search_events:csv_loader['local_path_to_file.csv', 'some-source-to-use-for-all-loaded-records']
   #
+  # @example
+  # bin/rails search_events:csv_loader['https://SERVER/remote_path_to_file.json', 'some-source-to-use-for-all-loaded-records']
+  #
   # @param path [String] local file path to a CSV file to load
   # @param source [String] source name to load the data under
   desc 'Load search_events from csv'
@@ -21,46 +24,20 @@ namespace :search_events do
     raise ArgumentError.new, 'Path is required' if args.path.blank?
     raise ArgumentError.new, 'Source is required' if args.source.blank?
 
-    Rails.logger.info("Loading data from #{args.path}")
+    # does the file look like a path or a URI
+    if URI(args.path).scheme
+      Rails.logger.info("Loading data from remote file #{args.path}")
+      data = URI.parse(args.path).open('rb', &:read)
+    else
+      Rails.logger.info("Loading data from local file #{args.path}")
+      data = File.read(args.path)
+    end
 
-    CSV.foreach(args.path) do |row|
+    # not ideal, we should consider streaming the file rather than loading it fully into memory
+    # if you run into issues with this, consider loading subsets (such as a single month) at a time
+    CSV.parse(data) do |row|
       term = Term.create_or_find_by!(phrase: row.first)
       term.search_events.create!(source: args.source, created_at: row.last)
     end
-  end
-
-  # url loader can bulk load SearchEvents and Terms.
-  #
-  # @note This is not for use in production. It is intended for use in review apps on Heroku, to load records in
-  #   preparation for demonstrations.
-  #
-  # @note the csv should be formated as `term phrase`, `timestamp`. A dataclip is available that can export in this
-  #   format.
-  #
-  # @example
-  # bin/rake search_events:url_loader['https://example.org/file.csv', 'some-source-to-use-for-all-loaded-records']
-  #
-  # @param addr [String] a URL for a CSV file to load
-  # @param source [String] source name to load the data under
-  desc 'Load search_events from url'
-  task :url_loader, %i[addr source] => :environment do |_task, args|
-    raise ArgumentError.new, 'URL is required' if args.addr.blank?
-    raise ArgumentError.new, 'Source is required' if args.source.blank?
-
-    Rails.logger.info("Term count before import: #{Term.count}")
-    Rails.logger.info("SearchEvent count before import: #{SearchEvent.count}")
-
-    url = URI.parse(args.addr)
-    Rails.logger.info("Loading data from #{url}")
-
-    file = url.open.read
-    data = CSV.parse(file)
-    data.each do |row|
-      term = Term.create_or_find_by!(phrase: row.first)
-      term.search_events.create!(source: args.source, created_at: row.last)
-    end
-
-    Rails.logger.info("Term count after import: #{Term.count}")
-    Rails.logger.info("SearchEvent count after import: #{SearchEvent.count}")
   end
 end

--- a/test/tasks/search_event_loader_rake_test.rb
+++ b/test/tasks/search_event_loader_rake_test.rb
@@ -6,32 +6,31 @@ require 'rake'
 class SearchEventLoaderRakeTest < ActiveSupport::TestCase
   def setup
     Tacos::Application.load_tasks if Rake::Task.tasks.empty?
-    Rake::Task['search_events:url_loader'].reenable
+    Rake::Task['search_events:csv_loader'].reenable
   end
 
-  test 'url_reload can accept a url and source parameter' do
+  test 'csv_loader can accept a url and source parameter' do
     records_before = SearchEvent.count
     VCR.use_cassette('search_events:url_loader from remote csv') do
       remote_file = 'http://static.lndo.site/search_events.csv'
-      Rake::Task['search_events:url_loader'].invoke(remote_file, 'test')
+      Rake::Task['search_events:csv_loader'].invoke(remote_file, 'test')
     end
 
     assert_not_equal records_before, SearchEvent.count
   end
 
-  test 'url_reload errors without any parameters' do
+  test 'csv_loader errors without any parameters' do
     error = assert_raises(ArgumentError) do
-      Rake::Task['search_events:url_loader'].invoke()
+      Rake::Task['search_events:csv_loader'].invoke
     end
-    assert_equal 'URL is required', error.message
+    assert_equal 'Path is required', error.message
   end
 
-  test 'url_reload errors without a source parameter' do
+  test 'csv_loader errors without a source parameter' do
     error = assert_raises(ArgumentError) do
       remote_file = 'http://static.lndo.site/search_events.csv'
-      Rake::Task['search_events:url_loader'].invoke(remote_file)
+      Rake::Task['search_events:csv_loader'].invoke(remote_file)
     end
     assert_equal 'Source is required', error.message
   end
-
 end

--- a/test/tasks/search_event_loader_rake_test.rb
+++ b/test/tasks/search_event_loader_rake_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class SearchEventLoaderRakeTest < ActiveSupport::TestCase
+  def setup
+    Tacos::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task['search_events:url_loader'].reenable
+  end
+
+  test 'url_reload can accept a url and source parameter' do
+    records_before = SearchEvent.count
+    VCR.use_cassette('search_events:url_loader from remote csv') do
+      remote_file = 'http://static.lndo.site/search_events.csv'
+      Rake::Task['search_events:url_loader'].invoke(remote_file, 'test')
+    end
+
+    assert_not_equal records_before, SearchEvent.count
+  end
+
+  test 'url_reload errors without any parameters' do
+    error = assert_raises(ArgumentError) do
+      Rake::Task['search_events:url_loader'].invoke()
+    end
+    assert_equal 'URL is required', error.message
+  end
+
+  test 'url_reload errors without a source parameter' do
+    error = assert_raises(ArgumentError) do
+      remote_file = 'http://static.lndo.site/search_events.csv'
+      Rake::Task['search_events:url_loader'].invoke(remote_file)
+    end
+    assert_equal 'Source is required', error.message
+  end
+
+end

--- a/test/vcr_cassettes/search_events_url_loader_from_remote_csv.yml
+++ b/test/vcr_cassettes/search_events_url_loader_from_remote_csv.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://static.lndo.site/search_events.csv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '92'
+      Content-Type:
+      - text/csv
+      Date:
+      - Wed, 28 Aug 2024 21:47:08 GMT
+      Etag:
+      - '"5c-620c52829ded5"'
+      Last-Modified:
+      - Wed, 28 Aug 2024 21:36:54 GMT
+      Server:
+      - Apache/2.4.54 (Debian)
+    body:
+      encoding: UTF-8
+      string: |
+        first search term,1996-04-13 19:30:00.000000
+        another search term,1999-05-15 19:30:00.000000
+  recorded_at: Wed, 28 Aug 2024 21:47:08 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
The initial development for this was a quick prototype to prepare for a demonstration within EngX. However, during our discussion it seems like this might be a good feature to develop further and land for real.

This adds a `search_events:url_loader` task that is based on the existing `search_events:csv_loader` task, with a bit of tweaking from `suggested_resources:reload` for dealing with remote URLs.

More details, including a discussion of a side effect, are in the commit message.

## Developer

### Ticket(s)

None

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed **(I've added a method comment, but don't see rake documentation in the yard output?)**
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
