### PR TITLE
Update Detectors to use phrase inputs instead of Terms

### DIFF
--- a/app/models/detector/lcsh.rb
+++ b/app/models/detector/lcsh.rb
@@ -12,9 +12,12 @@ class Detector
     # For now the initialize method just needs to run the pattern checker. A space for future development would be to
     # write additional methods to look up the detected LCSH for more information, and to confirm that the phrase is
     # actually an LCSH.
-    def initialize(term)
+    #
+    #   @param phrase String. Often a `Term.phrase`.
+    #   @return Nothing intentional. Data is written to Hash `@detections` during processing.
+    def initialize(phrase)
       @detections = {}
-      term_pattern_checker(term)
+      pattern_checker(phrase)
     end
 
     # The record method will consult the set of regex-based detectors that are defined in Detector::Lcsh. Any matches
@@ -41,10 +44,10 @@ class Detector
 
     private
 
-    # term_patterns are regex patterns that can be applied to indicate whether a search string is looking for an LCSH
+    # patterns are regex patterns that can be applied to indicate whether a search string is looking for an LCSH
     # string. At the moment there is only one - for the separator character " -- " - but others might be possible if
     # there are regex-able vocabulary quirks which might separate subject values from non-subject values.
-    def term_patterns
+    def patterns
       {
         separator: /(.*)\s--\s(.*)/
       }

--- a/app/models/detector/pattern_checker.rb
+++ b/app/models/detector/pattern_checker.rb
@@ -4,9 +4,13 @@ class Detector
   # PatternChecker is intended to be added to Detectors via `include Detector::PatternChecker` to make
   # these methods available to instances of the class
   module PatternChecker
-    def term_pattern_checker(term)
-      term_patterns.each_pair do |type, pattern|
-        @detections[type.to_sym] = match(pattern, term) if match(pattern, term).present?
+    # pattern_checker iterates over all patterns defined in the calling object's `pattern` method.
+    #
+    #   @param phrase [String]. Often a `Term.phrase`.
+    #   @return Nothing intentional. Data is written to Hash `@detections` during processing.
+    def pattern_checker(phrase)
+      patterns.each_pair do |type, pattern|
+        @detections[type.to_sym] = match(pattern, phrase) if match(pattern, phrase).present?
       end
     end
 
@@ -15,8 +19,13 @@ class Detector
     # might be expected, but just "1234-5678". Using ruby's string.scan(pattern) may be worthwhile if we want to detect
     # all possible matches instead of just the first. That may require a larger refactor though as initial tests of doing
     # that change did result in unintended results so it was backed out for now.
-    def match(pattern, term)
-      pattern.match(term).to_s.strip
+    #
+    #   @param pattern Regexp
+    #   @param phrase String. Often a `Term.phrase`.
+    #
+    #   @return String
+    def match(pattern, phrase)
+      pattern.match(phrase).to_s.strip
     end
   end
 end

--- a/app/models/detector/standard_identifiers.rb
+++ b/app/models/detector/standard_identifiers.rb
@@ -13,9 +13,12 @@ class Detector
     # shared instance methods
     include Detector::PatternChecker
 
-    def initialize(term)
+    # Initialization process will run pattern checkers and strip invalid ISSN detections.
+    #   @param phrase String. Often a `Term.phrase`.
+    #   @return Nothing intentional. Data is written to Hash `@detections` during processing.
+    def initialize(phrase)
       @detections = {}
-      term_pattern_checker(term)
+      pattern_checker(phrase)
       strip_invalid_issns
     end
 
@@ -43,8 +46,8 @@ class Detector
 
     private
 
-    # term_patterns are regex patterns to be applied to the basic search box input
-    def term_patterns
+    # patterns are regex patterns to be applied to the basic search box input
+    def patterns
       {
         isbn: /\b(ISBN-*(1[03])* *(: ){0,1})*(([0-9Xx][- ]*){13}|([0-9Xx][- ]*){10})\b/,
         issn: /\b[0-9]{4}-[0-9]{3}[0-9xX]\b/,

--- a/test/models/detector/lcsh_test.rb
+++ b/test/models/detector/lcsh_test.rb
@@ -10,8 +10,8 @@ class Detector
         'Space vehicles -- Materials -- Congresses'
       ]
 
-      true_samples.each do |term|
-        actual = Detector::Lcsh.new(term).detections
+      true_samples.each do |phrase|
+        actual = Detector::Lcsh.new(phrase).detections
 
         assert_includes(actual, :separator)
       end
@@ -25,8 +25,8 @@ class Detector
         'This one should--also not work'
       ]
 
-      false_samples.each do |term|
-        actual = Detector::Lcsh.new(term).detections
+      false_samples.each do |phrase|
+        actual = Detector::Lcsh.new(phrase).detections
 
         assert_not_includes(actual, :separator)
       end


### PR DESCRIPTION
Summary of changes (please refer to commit messages for full details):

- updated variable name in many detectors to better reflect we are expecting strings not Term objects
- refactored Citation to use strings and not Term objects to match our other Detectors

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-106

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
