### PR TITLE
Adds barnes gem to collect Ruby Language Metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# GC Statsd Reporter [https://github.com/heroku/barnes]
+gem 'barnes'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     attr_required (1.0.2)
+    barnes (0.0.9)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
@@ -230,6 +233,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -409,6 +413,7 @@ GEM
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
+    statsd-ruby (1.5.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringex (2.8.6)
@@ -469,6 +474,7 @@ PLATFORMS
 DEPENDENCIES
   administrate (~> 0.20.1)
   annotate
+  barnes
   bootsnap
   cancancan
   capybara

--- a/app.json
+++ b/app.json
@@ -26,6 +26,9 @@
   "buildpacks": [
     {
       "url": "heroku/ruby"
+    },
+    {
+      "url": "heroku/metrics"
     }
   ]
 }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,3 +33,11 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+require 'barnes'
+
+before_fork do
+  # worker specific setup
+
+  Barnes.start # Must have enabled worker mode for this to block to be called
+end


### PR DESCRIPTION
Why are these changes being introduced:

* This adds a few additional useful metrics in our heroku dashboard for stage/prod level apps (it doesn't work in eco dynos so pr builds will not collect this data)
* see also: https://devcenter.heroku.com/articles/language-runtime-metrics-ruby

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-78

How does this address that need:

* adds barnes gem
* configures puma per heroku docs to enable barnes
* updates app.json to add the metrics collection to PR builds even though they probably won't do anything in our eco dynos

Document any side effects to this change:

None really, but the only other rails app we do this with is Bento. Other apps should likely get updated to collect this data if we don't see any side effects.

## Developer

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

YES dependencies are updated

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [x] No additional test coverage is required.
