### PR TITLE
Change existing migration to create Category

### DIFF
--- a/db/migrate/20241204214748_change_column_null_confirmation_category.rb
+++ b/db/migrate/20241204214748_change_column_null_confirmation_category.rb
@@ -1,5 +1,10 @@
 class ChangeColumnNullConfirmationCategory < ActiveRecord::Migration[7.1]
   def change
+    Category.find_or_create_by(
+      name: 'Flagged',
+      description: 'A search which has sensitive information that should be excluded from further processing.'
+    )
+
     change_column_null :confirmations, :category_id, false, Category.find_by(name: 'Flagged').id
   end
 end


### PR DESCRIPTION
Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-125

How does this address that need:

* Creates a Category "Flagged" if one does not already exist before trying to update data based on this specific Category

Document any side effects to this change:

* This migration has already run and it is normally not a good practice to update migrations to prevent databases from not bein in synch with the migration. In this case, all this does is introduce the code that was run manually in environments where this was run so it is fine and expected that those environments will not run it again.

## Developer

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

YES migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
