### PR TITLE
Revert sqlite3 to 1.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,8 @@ group :development, :test do
   gem 'dotenv-rails'
 
   # Use sqlite as the database for Active Record in dev and test
-  gem 'sqlite3'
+  # This needs to be 1.7 until we figure out how to avoid the problem of forked processes that we ran into with 2.x
+  gem 'sqlite3', '~> 1.7'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,10 +426,10 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.4.1-aarch64-linux-gnu)
-    sqlite3 (2.4.1-arm64-darwin)
-    sqlite3 (2.4.1-x86_64-darwin)
-    sqlite3 (2.4.1-x86_64-linux-gnu)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     statsd-ruby (1.5.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
@@ -527,7 +527,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   sprockets-rails
-  sqlite3
+  sqlite3 (~> 1.7)
   stimulus-rails
   stringex
   turbo-rails


### PR DESCRIPTION
Brief reversion for SQLite3 back to version 1.7, after running into local issues using 2.4