### PR TITLE
Validate ISBNs detected via regex

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---no-private --protected app/**/*.rb - docs/**/*.md
+--private --protected app/**/*.rb - docs/**/*.md

--- a/app/models/detector/standard_identifiers.rb
+++ b/app/models/detector/standard_identifiers.rb
@@ -102,7 +102,7 @@ class Detector
     def valid_isbn_10?(digits)
       sum = 0
       digits.each_with_index do |digit, index|
-        digit = '10' if digit.downcase == 'x'
+        digit = '10' if digit.casecmp('x').zero?
         sum += digit.to_i * (10 - index)
       end
       (sum % 11).zero?

--- a/test/models/detector/standard_identifiers_test.rb
+++ b/test/models/detector/standard_identifiers_test.rb
@@ -23,6 +23,19 @@ class Detector
       end
     end
 
+    test 'ISBN-10 examples with incorrect check digits are not detected' do
+      # from wikipedia
+      samples = ['99921-58-10-1', '9971-5-0210-1', '960-425-059-1', '80-902734-1-1', '85-359-0277-1',
+                 '1-84356-028-1', '0-684-84328-1', '0-8044-2957-1', '0-85131-041-1', '93-86954-21-1', '0-943396-04-1',
+                 '0-9752298-0-1']
+
+      samples.each do |isbn|
+        actual = Detector::StandardIdentifiers.new(isbn).detections
+
+        assert_nil(actual[:isbn])
+      end
+    end
+
     test 'ISBN-13 examples' do
       samples = ['978-99921-58-10-4', '978-9971-5-0210-2', '978-960-425-059-2', '978-80-902734-1-2',
                  '978-85-359-0277-8', '978-1-84356-028-9', '978-0-684-84328-5', '978-0-8044-2957-3',
@@ -33,6 +46,19 @@ class Detector
         actual = Detector::StandardIdentifiers.new(isbn).detections
 
         assert_equal(isbn, actual[:isbn])
+      end
+    end
+
+    test 'ISBN-13 examples with incorrect check digits are not detected' do
+      samples = ['978-99921-58-10-1', '978-9971-5-0210-1', '978-960-425-059-1', '978-80-902734-1-1',
+                 '978-85-359-0277-1', '978-1-84356-028-1', '978-0-684-84328-1', '978-0-8044-2957-1',
+                 '978-0-85131-041-2', '978-93-86954-21-1', '978-0-943396-04-1', '978-0-9752298-0-1', '9798531132171',
+                 '9798577456831', '979-8-886-45174-1', '9781319145441']
+
+      samples.each do |isbn|
+        actual = Detector::StandardIdentifiers.new(isbn).detections
+
+        assert_nil(actual[:isbn])
       end
     end
 

--- a/test/models/detector/standard_identifiers_test.rb
+++ b/test/models/detector/standard_identifiers_test.rb
@@ -24,9 +24,10 @@ class Detector
     end
 
     test 'ISBN-13 examples' do
-      samples = ['978-99921-58-10-7', '979-9971-5-0210-0', '978-960-425-059-0', '979-80-902734-1-6', '978-85-359-0277-5',
-                 '979-1-84356-028-3', '978-0-684-84328-5', '979-0-8044-2957-X', '978-0-85131-041-9', '979-93-86954-21-4',
-                 '978-0-943396-04-2', '979-0-9752298-0-X']
+      samples = ['978-99921-58-10-4', '978-9971-5-0210-2', '978-960-425-059-2', '978-80-902734-1-2',
+                 '978-85-359-0277-8', '978-1-84356-028-9', '978-0-684-84328-5', '978-0-8044-2957-3',
+                 '978-0-85131-041-1', '978-93-86954-21-3', '978-0-943396-04-0', '978-0-9752298-0-4', '9798531132178',
+                 '9798577456832', '979-8-886-45174-0', '9781319145446']
 
       samples.each do |isbn|
         actual = Detector::StandardIdentifiers.new(isbn).detections
@@ -36,7 +37,7 @@ class Detector
     end
 
     test 'not ISBNs' do
-      samples = ['orange cats like popcorn', '1234-6798', 'another ISBN not found here']
+      samples = ['orange cats like popcorn', '1234-6798', 'another ISBN not found here', '99921-58-10-1', '979-8-886-45174-1']
 
       samples.each do |notisbn|
         actual = Detector::StandardIdentifiers.new(notisbn).detections


### PR DESCRIPTION
Why are these changes being introduced:

* It is not possible to validate detected ISBNs via regex alone
* We are seeing false positives for ISBNs in production that are invalid
* We validate ISSNs, but had not gone back and added this logic to ISBN

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-114

How does this address that need:

* Follows the pattern to strip detected ISBNs in a way similar to ISSNs
* Follows the ISBN-10 and ISBN-13 validation specifications
* Updates tests for valid ISBNs are actually using valid ISBNs (previously, the ISBN-10s were incorrect converted to ISBN-13s)
* Adds additional ISBN-13 examples to test positive validations
* Adds additional ISBN-13 examples to test negative validations

Document any side effects to this change:

* Removed "ISBN: " optional portion of the ISBN detection. It didn't feel useful and needed to be stripped out before validation (which felt like it supported to me that it wasn't part of the ISBN and shouldn't be detected)
* Updated yardopts to include private methods. We do a lot of important work in private methods. While we shouldn't call them from outside of the instance, having them in the docs feels better as some of our docs were effectively making Classes look like black boxes without this change.
* Some of our test ISBN-13s were invalid. The ISBN-10 list was run through an external ISBN-10 to ISBN-13 convertor. As all of those will start with 978 prefixes, I manually added some valid ISBN-13 examples to the tests that started with the other valid prefix (979).

Example query. Run in prod, this will show a detected ISBN that then fails the details lookup as it isn't actually valid. In the PR build or locally with this branch, it does not detect the invalid ISBN

```graphql
{
  logSearchEvent(
    searchTerm: "Artin, M. Algebra (2nd Edition). Addison Wesley, 2010. ISBN: 9780132413771"
    sourceSystem: "playground"
  ) {
    phrase
    categories {
      name
      confidence
    }
    detectors {
      standardIdentifiers {
        kind
        value
        details {
          linkResolverUrl
        }
      }
    }
  }
}
```


## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-###

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
