### PR TITLE
Authenticated users terms and playground access

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,6 +23,15 @@ class Ability
     # Allow all authenticated users to view reports
     can :view, :report
 
+    # All users can see search events and terms
+    can %w[index show], :search_event
+    can %i[read view], SearchEvent
+    can %w[index show], :term
+    can %i[read view], Term
+
+    # All users can use playground
+    can :view, :playground
+
     # Create manual confirmation
     can :manage, :confirmations
     can :manage, Confirmation

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -26,14 +26,11 @@ class StaticControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'playground url is not accessible to basic users when authenticated' do
+  test 'playground url is accessible to basic users when authenticated' do
     sign_in users(:basic)
 
     get '/playground'
 
-    assert_redirected_to '/'
-    follow_redirect!
-
-    assert_select 'div.alert', text: 'Not authorized.', count: 1
+    assert_response :success
   end
 end

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -21,15 +21,12 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert', text: 'Please sign in to continue', count: 1
   end
 
-  test 'authenticated users without admin status still cannot access admin area' do
+  test 'authenticated users without admin status can access admin area' do
     mock_auth(users(:basic))
     get '/admin'
 
-    assert_response :redirect
-    follow_redirect!
-
-    assert_equal '/', path
-    assert_select 'div.alert', text: 'Not authorized', count: 1
+    assert_response :ok
+    assert_equal '/admin', path
   end
 
   test 'admin users can access admin area' do


### PR DESCRIPTION
Why are these changes being introduced:

* we have users that should have access to term/search event data
* eventually, we will likely create a specific role for that, but for now the user list is so small this is fine
* playground access is also being given, mostly as a convenience in PR builds to not have to manually assign admin permissions to get that feature

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-133

How does this address that need:

* Allows read access to Terms/SearchEvents to all authenticated users
* Allows playground access to all authenticated users

Document any side effects to this change:

* Playground access used without care could log additional searchevents as if they came from a production system that actually came from the playground

Summary of changes (please refer to commit messages for full details)

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-###

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [x] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
