### PR TITLE
Add option to confirm only categorized terms

### DIFF
--- a/app/controllers/term_controller.rb
+++ b/app/controllers/term_controller.rb
@@ -3,8 +3,15 @@
 class TermController < ApplicationController
   include Pagy::Backend
 
-  # This provides the list of terms that are awaiting confirmation.
+  # This provides the list of terms that are awaiting confirmation. By default this shows only terms which have been
+  # categorized automatically. Adding `type=all` to the querystring will show _all_ terms which the user has not yet
+  # confirmed.
   def unconfirmed
-    @pagy, @records = pagy(Term.user_unconfirmed)
+    terms = if params[:show] == 'all'
+              Term.user_unconfirmed
+            else
+              Term.categorized.user_unconfirmed
+            end
+    @pagy, @records = pagy(terms)
   end
 end

--- a/app/controllers/term_controller.rb
+++ b/app/controllers/term_controller.rb
@@ -8,6 +8,7 @@ class TermController < ApplicationController
   # confirmed.
   def unconfirmed
     terms = if params[:show] == 'all'
+              authorize! :confirm_uncategorized, Term
               Term.user_unconfirmed
             else
               Term.categorized.user_unconfirmed

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,6 +40,7 @@ class Ability
     # Rules for admins
     return unless user.admin?
 
+    can :confirm_uncategorized, Term
     can :manage, :all
   end
 end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -24,6 +24,7 @@ class Term < ApplicationRecord
   before_save :register_fingerprint
   after_destroy :check_fingerprint_count
 
+  scope :categorized, -> { where.associated(:categorizations).distinct }
   scope :user_confirmed, -> { where.associated(:confirmations).distinct }
   scope :user_unconfirmed, -> { where.missing(:confirmations).distinct }
 

--- a/app/views/term/unconfirmed.html.erb
+++ b/app/views/term/unconfirmed.html.erb
@@ -3,10 +3,12 @@
 <p>The terms listed here have not yet been reviewed by a person and placed into a category. Clicking on any term will
 take you to the form for submitting this information.</p>
 
+<% if can? :confirm_uncategorized, Term %>
 <p class="wrap-filters">View:
   <a class="btn button-small button-secondary" href="<%= terms_unconfirmed_path %>">Categorized terms</a>
   <a class="btn button-small button-secondary" href="<%= terms_unconfirmed_path(show: 'all') %>">All terms</a>
 </p>
+<% end %>
 
 <p><%== pagy_info(@pagy) %></p>
 

--- a/app/views/term/unconfirmed.html.erb
+++ b/app/views/term/unconfirmed.html.erb
@@ -3,6 +3,11 @@
 <p>The terms listed here have not yet been reviewed by a person and placed into a category. Clicking on any term will
 take you to the form for submitting this information.</p>
 
+<p class="wrap-filters">View:
+  <a class="btn button-small button-secondary" href="<%= terms_unconfirmed_path %>">Categorized terms</a>
+  <a class="btn button-small button-secondary" href="<%= terms_unconfirmed_path(show: 'all') %>">All terms</a>
+</p>
+
 <p><%== pagy_info(@pagy) %></p>
 
 <ul class="list-unbulleted">

--- a/test/controllers/term_controller_test.rb
+++ b/test/controllers/term_controller_test.rb
@@ -25,4 +25,21 @@ class TermControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test 'confirmation index can show two different sets of terms' do
+    sign_in users(:basic)
+    get terms_unconfirmed_path
+
+    # default_pagy will be something like "Displaying 10 items"
+    default_pagy = response.parsed_body.xpath('//main//span').first.text
+    default_pagy_count = default_pagy.split.second.to_i
+
+    get terms_unconfirmed_path(show: 'all')
+
+    # The '?type=all' route asks for more records, so the count should be higher
+    all_pagy = response.parsed_body.xpath('//main//span').first.text
+    all_pagy_count = all_pagy.split.second.to_i
+
+    assert_operator all_pagy_count, :>, default_pagy_count
+  end
 end

--- a/test/controllers/term_controller_test.rb
+++ b/test/controllers/term_controller_test.rb
@@ -26,8 +26,39 @@ class TermControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'confirmation index can show two different sets of terms' do
+  test 'basic users see only one confirmation option' do
     sign_in users(:basic)
+    get terms_unconfirmed_path
+
+    assert_select 'p.wrap-filters', text: "View:\n  Categorized terms\n  All terms", count: 0
+  end
+
+  test 'admin users see two confirmation options' do
+    sign_in users(:admin)
+    get terms_unconfirmed_path
+
+    assert_select 'p.wrap-filters', text: "View:\n  Categorized terms\n  All terms", count: 1
+  end
+
+  test 'basic users cannot access the confirmation option for uncategorized terms' do
+    sign_in users(:basic)
+    get terms_unconfirmed_path(show: 'all')
+
+    assert_redirected_to '/'
+    follow_redirect!
+
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'admin users can access the confirmation option for uncategorized terms' do
+    sign_in users(:admin)
+    get terms_unconfirmed_path(show: 'all')
+
+    assert_response :success
+  end
+
+  test 'confirmation index can show two different sets of terms for admin users' do
+    sign_in users(:admin)
     get terms_unconfirmed_path
 
     # default_pagy will be something like "Displaying 10 items"

--- a/test/models/term_test.rb
+++ b/test/models/term_test.rb
@@ -299,6 +299,32 @@ class TermTest < ActiveSupport::TestCase
     end
   end
 
+  test 'categorized scope returns an active record relation' do
+    assert_kind_of ActiveRecord::Relation, Term.categorized
+  end
+
+  test 'categorized scope accounts for terms with multiple categorizations' do
+    categorized_count = Term.categorized.count
+    t = terms('doi')
+
+    term_category_count = t.categorizations.count
+
+    # term has been categorized already
+    assert_operator 1, :<=, term_category_count
+
+    new_record = {
+      term: t,
+      category: categories('navigational'),
+      confidence: 0.5,
+      detector_version: '1'
+    }
+    Categorization.create!(new_record)
+
+    # The term has gained a category, but the categorized scope has not changed size.
+    assert_operator term_category_count, :<, t.categorizations.count
+    assert_equal categorized_count, Term.categorized.count
+  end
+
   test 'user_confirmed scope returns an active record relation' do
     assert_kind_of ActiveRecord::Relation, Term.user_confirmed
   end

--- a/test/models/term_test.rb
+++ b/test/models/term_test.rb
@@ -306,11 +306,10 @@ class TermTest < ActiveSupport::TestCase
   test 'categorized scope accounts for terms with multiple categorizations' do
     categorized_count = Term.categorized.count
     t = terms('doi')
-
-    term_category_count = t.categorizations.count
+    orig_categorization_count = t.categorizations.count
 
     # term has been categorized already
-    assert_operator 1, :<=, term_category_count
+    assert_operator 1, :<=, orig_categorization_count
 
     new_record = {
       term: t,
@@ -321,7 +320,7 @@ class TermTest < ActiveSupport::TestCase
     Categorization.create!(new_record)
 
     # The term has gained a category, but the categorized scope has not changed size.
-    assert_operator term_category_count, :<, t.categorizations.count
+    assert_operator orig_categorization_count, :<, t.categorizations.count
     assert_equal categorized_count, Term.categorized.count
   end
 


### PR DESCRIPTION
## Developer

### Why are these changes being introduced:

The confirmation workflow was predicated on humans providing a second opinion on categorization, allowing us to review how the application is already performing. However, when we initially rolled out this workflow, it allowed humans to provide confirmation on every term in the system, and not just those which the system had categorized.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/tco-126

### How does this address that need:

This adds:

* A categorized scope to the Term model

* Forks the logic in the term controller's "unconfirmed" method, returning two different recordsets. By default it includes only categorized terms (via the scope added above). However, there is a URL parameter to leave this restriction out.

* The template for this list of terms has buttons to switch between the two modes. The default behavior applies the categorized scope, while we can still see all terms via the other button.

* We add tests for both the model scope and the branching logic in the controller, making sure that they behave as expected.

### Document any side effects to this change:

* I'm a little concerned that I've missed writing tests in some cases, but I think this covers most of the feature.

### Accessibility

- [x] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [ ] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed
- [ ] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [ ] I have confirmed that the code works as intended.
- [ ] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [ ] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

### Testing

- [ ] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
