### PR TITLE
Add LibKey API option for DOI and PMID metadata

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
 DETECTOR_VERSION=1
 LINKRESOLVER_BASEURL=https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/mit.tacos.api&vid=01MIT_INST:MIT
 TACOS_EMAIL=tacos-help@mit.edu
+LIBKEY_KEY=FAKE_LIBKEY_KEY
+LIBKEY_ID=FAKE_LIBKEY_ID

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ changes, this is the signal which indicates that terms need to be re-evaluated.
 
 ### Optional
 
+`LIBKEY_KEY`: LibKey API key. Required if `LIBKEY_DOI` or `LIBKEY_PMID` are set.
+`LIBKEY_ID`: LibKey Library ID. Required if `LIBKEY_DOI` or `LIBKEY_PMID` are set.
+`LIBKEY_DOI`: If set, use LibKey for DOI metadata lookups. If not set, Unpaywall is used.
+`LIBKEY_PMID`: If set, use LibKey for PMID metadata lookups. If not set, NCBI Entrez is used.
+
 `PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes
 from our theme gem.
 

--- a/app/graphql/types/details_type.rb
+++ b/app/graphql/types/details_type.rb
@@ -7,10 +7,13 @@ module Types
     field :date, String
     field :doi, String
     field :issns, [String]
+    field :journal_image, String
+    field :journal_link, String
     field :journal_name, String
     field :link_resolver_url, String
     field :oa, Boolean
     field :oa_status, String
+    field :pmid, String
     field :publisher, String
     field :title, String
 
@@ -19,7 +22,7 @@ module Types
     end
 
     def authors
-      @object[:authors]&.split(',')
+      @object[:authors]&.split(';')
     end
   end
 end

--- a/app/graphql/types/standard_identifiers_type.rb
+++ b/app/graphql/types/standard_identifiers_type.rb
@@ -15,12 +15,30 @@ module Types
       when :barcode
         LookupBarcode.new.info(@object[:value])
       when :doi
-        LookupDoi.new.info(@object[:value])
+        doi
       when :isbn
         LookupIsbn.new.info(@object[:value])
       when :issn
         LookupIssn.new.info(@object[:value])
       when :pmid
+        pmid
+      end
+    end
+
+    # doi handles determining which doi lookup method to use
+    def doi
+      if ENV.fetch('LIBKEY_DOI', false)
+        LookupLibkey.info(doi: @object[:value])
+      else
+        LookupDoi.new.info(@object[:value])
+      end
+    end
+
+    # pmid handles determining which pmid lookup method to use
+    def pmid
+      if ENV.fetch('LIBKEY_PMID', false)
+        LookupLibkey.info(pmid: @object[:value])
+      else
         LookupPmid.new.info(@object[:value].split.last)
       end
     end

--- a/app/models/detector/standard_identifiers.rb
+++ b/app/models/detector/standard_identifiers.rb
@@ -26,6 +26,7 @@ class Detector
       pattern_checker(phrase)
       strip_invalid_issns
       strip_invalid_isbns
+      strip_pmid_prefix
     end
 
     # The record method will consult the set of regex-based detectors that are defined in
@@ -61,6 +62,12 @@ class Detector
         pmid: /\b((pmid|PMID):\s?(\d{7,8}))\b/,
         doi: %r{\b10\.(\d+\.*)+/(([^\s.])+\.*)+\b}
       }
+    end
+
+    # strip_pmid_prefix removes the PMID:/pmid: prefix from the detected value. The regex needs that, but the
+    # actual value of the identifier should not include those prefixes.
+    def strip_pmid_prefix
+      @detections[:pmid] = @detections[:pmid].gsub(/pmid:|PMID:/, '').strip if @detections[:pmid].present?
     end
 
     # strip_invalid_isbns coordinates the logic to remove ISBNs that are not valid from our list of detected ISBNs

--- a/app/models/lookup_barcode.rb
+++ b/app/models/lookup_barcode.rb
@@ -37,8 +37,16 @@ class LookupBarcode
       title: xml.xpath('//dc:title', 'dc' => 'http://purl.org/dc/elements/1.1/').text,
       date: xml.xpath('//dc:date', 'dc' => 'http://purl.org/dc/elements/1.1/').text,
       publisher: xml.xpath('//dc:publisher', 'dc' => 'http://purl.org/dc/elements/1.1/').text,
-      authors: xml.xpath('//dc:contributor', 'dc' => 'http://purl.org/dc/elements/1.1/').text
+      authors: authors(xml)
     }
+  end
+
+  def authors(xml)
+    authors = []
+    xml.xpath('//dc:contributor', 'dc' => 'http://purl.org/dc/elements/1.1/').each do |author|
+      authors << author.text
+    end
+    authors.join(';')
   end
 
   def url(barcode)

--- a/app/models/lookup_isbn.rb
+++ b/app/models/lookup_isbn.rb
@@ -32,7 +32,7 @@ class LookupIsbn
       json = parse_response(url)
       json['name']
     end
-    author_names.join(' ; ')
+    author_names.join(';')
   end
 
   def parse_response(url)

--- a/app/models/lookup_libkey.rb
+++ b/app/models/lookup_libkey.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# LookupLibkey can take a DOI or PMID and return metadata, link resolver links, and journal browse links.
+class LookupLibkey
+  BASEURL = 'https://public-api.thirdiron.com/public/v1/libraries'
+
+  # Info is the main entry point into the LookupLibkey Class.
+  #
+  # @param doi [String]
+  # @param pmid [String]
+  # @return [Hash] or nil
+  def self.info(doi: nil, pmid: nil)
+    return unless expected_env?
+
+    if doi.present?
+      external_url = construct_url(doi:)
+      Rails.logger.debug(external_url)
+      external_data = fetch(external_url)
+      return if external_data == 'Error'
+
+      extract_metadata(external_data)
+    elsif pmid.present?
+      external_url = construct_url(pmid:)
+      Rails.logger.debug(external_url)
+
+      external_data = fetch(external_url)
+      return if external_data == 'Error'
+
+      extract_metadata(external_data)
+    else
+      Rails.logger.error('No doi or pmid provided to LookupLibkey')
+      nil
+    end
+  end
+
+  # expected_env? confirms both required variables are set
+  #
+  # @return Boolean
+  def self.expected_env?
+    Rails.logger.error('No LIBKEY_KEY set') if libkey_key.nil?
+
+    Rails.logger.error('No LIBKEY_ID set') if libkey_id.nil?
+
+    libkey_id.present? && libkey_key.present?
+  end
+
+  # using method instead of constant to allow for mutating in testing without causing sporadic failures
+  def self.libkey_key
+    ENV.fetch('LIBKEY_KEY', nil)
+  end
+
+  # using method instead of constant to allow for mutating in testing without causing sporadic failures
+  def self.libkey_id
+    ENV.fetch('LIBKEY_ID', nil)
+  end
+
+  # extract_metadata maps data from the LibKey response to an internal hash
+  #
+  # @return Hash
+  def self.extract_metadata(external_data)
+    {
+      title: external_data['data']['title'],
+      authors: external_data['data']['authors'].gsub('; ', ';'),
+      doi: external_data['data']['doi'],
+      pmid: external_data['data']['pmid'],
+      oa: external_data['data']['openAccess'],
+      date: external_data['data']['date'],
+      journal_name: external_data['included'].first['title'],
+      journal_issns: external_data['included'].first['issn'],
+      journal_image: external_data['included'].first['coverImageUrl'],
+      journal_link: external_data['included'].first['browzineWebLink'],
+      link_resolver_url: external_data['data']['bestIntegratorLink']['bestLink']
+    }
+  end
+
+  # https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/65929220/BrowZine+Public+API+Overview
+  # https://thirdiron.atlassian.net/wiki/spaces/BrowZineAPIDocs/pages/65699928/Article+DOI+PMID+Lookup+Endpoint+LibKey
+  # public/v1/libraries/:library_id/articles/doi/:article_doi?access_token=ffffffff-ffff-ffff-ffff-ffffffffffff
+  # /public/v1/libraries/:library_id/articles/pmid/:article_pmid?access_token=ffffffff-ffff-ffff-ffff-ffffffffffff
+  def self.construct_url(doi: nil, pmid: nil)
+    if doi.present?
+      "#{BASEURL}/#{libkey_id}/articles/doi/#{doi}?include=journal&access_token=#{libkey_key}"
+    elsif pmid.present?
+      "#{BASEURL}/#{libkey_id}/articles/pmid/#{pmid}?include=journal&access_token=#{libkey_key}"
+    else
+      Rails.logger.error('No PMID or DOI provided to LookupLibkey.url()')
+      nil
+    end
+  end
+
+  # Fetch performs the HTTP calls, parses JSON for successful requests.
+  def self.fetch(url)
+    resp = HTTP.headers(accept: 'application/json').get(url)
+    if resp.status == 200
+      JSON.parse(resp.to_s)
+    else
+      Rails.logger.debug do
+        'Fact lookup error. DOI or PMID detected but LibKey returned no data or otherwise errored'
+      end
+      Rails.logger.debug { "Response status: #{resp.status}" }
+      Rails.logger.debug { "URL: #{url}" }
+      'Error'
+    end
+  end
+end

--- a/test/models/detector/standard_identifiers_test.rb
+++ b/test/models/detector/standard_identifiers_test.rb
@@ -195,7 +195,7 @@ class Detector
     test 'pmid detected in string' do
       actual = Detector::StandardIdentifiers.new('Citation and stuff PMID: 35648703 more stuff.').detections
 
-      assert_equal('PMID: 35648703', actual[:pmid])
+      assert_equal('35648703', actual[:pmid])
     end
 
     test 'pmid examples' do
@@ -204,7 +204,7 @@ class Detector
       samples.each do |pmid|
         actual = Detector::StandardIdentifiers.new(pmid).detections
 
-        assert_equal(pmid, actual[:pmid])
+        assert_equal(pmid.gsub(/PMID:|pmid:/, '').strip, actual[:pmid])
       end
     end
 

--- a/test/models/lookup_libkey_test.rb
+++ b/test/models/lookup_libkey_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LookupLibkeyTest < ActiveSupport::TestCase
+  test 'metadata object is returned with expected fields for dois' do
+    VCR.use_cassette('libkey doi 10.1038/d41586-023-03497-2') do
+      metadata = LookupLibkey.info(doi: '10.1038/d41586-023-03497-2')
+
+      expected_keys = %i[title authors doi pmid oa date journal_name journal_issns journal_image journal_link
+                         link_resolver_url]
+
+      expected_keys.each do |key|
+        assert_includes(metadata.keys, key)
+      end
+    end
+  end
+
+  test 'metadata object is returned with expected fields for pmids' do
+    VCR.use_cassette('libkey pmid 10490598') do
+      metadata = LookupLibkey.info(pmid: '10490598')
+
+      expected_keys = %i[title authors doi pmid oa date journal_name journal_issns journal_image journal_link
+                         link_resolver_url]
+
+      expected_keys.each do |key|
+        assert_includes(metadata.keys, key)
+      end
+    end
+  end
+
+  test 'link resolver url returns expected value for dois' do
+    VCR.use_cassette('libkey doi 10.1038/d41586-023-03497-2') do
+      metadata = LookupLibkey.info(doi: '10.1038/d41586-023-03497-2')
+
+      expected_url = 'https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/594388926/full-text-file?utm_source=api_3735'
+
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'link resolver url returns expected value for pmids' do
+    VCR.use_cassette('libkey pmid 10490598') do
+      metadata = LookupLibkey.info(pmid: '10490598')
+
+      expected_url = 'https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/56753128/full-text-file?utm_source=api_3735'
+
+      assert_equal(expected_url, metadata[:link_resolver_url])
+    end
+  end
+
+  test 'doi or pmid are required' do
+    error = assert_raises(ArgumentError) do
+      LookupLibkey.info('no pmid or doi argument name given')
+    end
+    assert_equal 'wrong number of arguments (given 1, expected 0)', error.message
+  end
+
+  test 'LIBKEY_KEY is required' do
+    ClimateControl.modify LIBKEY_KEY: nil do
+      assert_nil(LookupLibkey.info(doi: '10.1038/d41586-023-03497-2'))
+    end
+  end
+
+  test 'LIBKEY_ID is required' do
+    ClimateControl.modify LIBKEY_ID: nil do
+      assert_nil(LookupLibkey.info(doi: '10.1038/d41586-023-03497-2'))
+    end
+  end
+
+  test 'blank doi and blank pmid returns nil' do
+    metadata = LookupLibkey.info(doi: '')
+
+    assert_nil(metadata)
+
+    metadata = LookupLibkey.info(pmid: '')
+
+    assert_nil(metadata)
+
+    metadata = LookupLibkey.info(pmid: '', doi: '')
+
+    assert_nil(metadata)
+  end
+
+  test 'contstruct url for doi' do
+    expected_url = 'https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/doi/my_doi?include=journal&access_token=FAKE_LIBKEY_KEY'
+    actual_url = LookupLibkey.construct_url(doi: 'my_doi')
+
+    assert_equal(expected_url, actual_url)
+  end
+
+  test 'contstruct url for pmid' do
+    expected_url = 'https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/pmid/my_pmid?include=journal&access_token=FAKE_LIBKEY_KEY'
+    actual_url = LookupLibkey.construct_url(pmid: 'my_pmid')
+
+    assert_equal(expected_url, actual_url)
+  end
+
+  test 'construct url with no pmid or do returns nil' do
+    actual_url = LookupLibkey.send(:construct_url)
+
+    assert_nil(actual_url)
+  end
+
+  test 'invalid doi lookup returns nil' do
+    VCR.use_cassette('libkey doi nonsense') do
+      metadata = LookupLibkey.info(doi: 'nonsense')
+
+      assert_nil(metadata)
+    end
+  end
+
+  test 'invalid pmid lookup returns nil' do
+    VCR.use_cassette('libkey pmid nonsense') do
+      metadata = LookupLibkey.info(pmid: 'nonsense')
+
+      assert_nil(metadata)
+    end
+  end
+end

--- a/test/models/lookup_libkey_test.rb
+++ b/test/models/lookup_libkey_test.rb
@@ -97,7 +97,7 @@ class LookupLibkeyTest < ActiveSupport::TestCase
   end
 
   test 'construct url with no pmid or do returns nil' do
-    actual_url = LookupLibkey.send(:construct_url)
+    actual_url = LookupLibkey.construct_url
 
     assert_nil(actual_url)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,15 @@ VCR.configure do |config|
     ENV.fetch('TACOS_EMAIL', nil).to_s
   end
 
+  # Filter Libkey Key
+  config.filter_sensitive_data('FAKE_LIBKEY_KEY') do
+    ENV.fetch('LIBKEY_KEY', nil).to_s
+  end
+  # Filter LibKey ID
+  config.filter_sensitive_data('FAKE_LIBKEY_ID') do
+    ENV.fetch('LIBKEY_ID', nil).to_s
+  end
+
   config.before_record do |interaction|
     header = interaction.response&.headers&.[]('Report-To')
     header&.each do |redacted_text|

--- a/test/vcr_cassettes/libkey_doi_10_1038/d41586-023-03497-2.yml
+++ b/test/vcr_cassettes/libkey_doi_10_1038/d41586-023-03497-2.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/doi/10.1038/d41586-023-03497-2?access_token=FAKE_LIBKEY_KEY&include=journal
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - public-api.thirdiron.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Report-To:
+      - "<REDACTED_REPORT_TO>"
+      Reporting-Endpoints:
+      - "<REDACTED_REPORTING_ENDPOINT>"
+      Nel:
+      - "<REDACTED_NEL>"
+      Connection:
+      - close
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,PATCH,POST,PUT
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Ratelimit-Limit:
+      - '7000'
+      X-Ratelimit-Remaining:
+      - '6998'
+      X-Ratelimit-Reset:
+      - '1738013436'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1652'
+      Etag:
+      - W/"674-i4jrBOQt3nhWgad5FEnF7B4fIr0"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 27 Jan 2025 21:29:35 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":594388926,"type":"articles","title":"Flashy molecules
+        decode a polymer’s lengthening chain","date":"2023-11-09","authors":"","inPress":false,"abandoned":false,"doi":"10.1038/d41586-023-03497-2","linkResolverOpenUrl":"https://mit.primo.exlibrisgroup.com/openurl/01MIT_INST/01MIT_INST:LIBKEY?genre=article&aulast=&issn=0028-0836&title=Nature&atitle=Flashy%20molecules%20decode%20a%20polymer%E2%80%99s%20lengthening%20chain&volume=623&issue=7988&spage=669&epage=669&date=2023-11-09&doi=10.1038%2Fd41586-023-03497-2&rft_id=info:pmid/37953305&sid=LibKey","pmid":"37953305","openAccess":false,"unpaywallUsable":true,"fullTextFile":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/594388926/full-text-file?utm_source=api_3735","contentLocation":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/594388926/content-location?utm_source=api_3735","availableThroughBrowzine":true,"startPage":"669","endPage":"669","avoidUnpaywallPublisherLinks":true,"browzineWebLink":"https://browzine.com/libraries/FAKE_LIBKEY_ID/journals/13191/issues/542328579?showArticleInContext=doi:10.1038%2Fd41586-023-03497-2&utm_source=api_3735","relationships":{"journal":{"data":{"type":"journals","id":13191}}},"bestIntegratorLink":{"bestLink":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/594388926/full-text-file?utm_source=api_3735","linkType":"fullTextFile","recommendedLinkText":"Download
+        PDF"}},"included":[{"id":13191,"type":"journals","title":"Nature","issn":"00280836","sjrValue":18.509,"coverImageUrl":"https://s3.amazonaws.com/thirdiron-assets/images/covers/0028-0836.png","browzineEnabled":true,"browzineWebLink":"https://browzine.com/libraries/FAKE_LIBKEY_ID/journals/13191?utm_source=api_3735"}]}'
+  recorded_at: Mon, 27 Jan 2025 21:29:35 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/libkey_doi_nonsense.yml
+++ b/test/vcr_cassettes/libkey_doi_nonsense.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/doi/nonsense?access_token=FAKE_LIBKEY_KEY&include=journal
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - public-api.thirdiron.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Report-To:
+      - "<REDACTED_REPORT_TO>"
+      Reporting-Endpoints:
+      - "<REDACTED_REPORTING_ENDPOINT>"
+      Nel:
+      - "<REDACTED_NEL>"
+      Connection:
+      - close
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,PATCH,POST,PUT
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Ratelimit-Limit:
+      - '7000'
+      X-Ratelimit-Remaining:
+      - '6999'
+      X-Ratelimit-Reset:
+      - '1738347313'
+      Date:
+      - Fri, 31 Jan 2025 18:14:12 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Fri, 31 Jan 2025 18:14:12 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/libkey_pmid_10490598.yml
+++ b/test/vcr_cassettes/libkey_pmid_10490598.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/pmid/10490598?access_token=FAKE_LIBKEY_KEY&include=journal
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - public-api.thirdiron.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Report-To:
+      - "<REDACTED_REPORT_TO>"
+      Reporting-Endpoints:
+      - "<REDACTED_REPORTING_ENDPOINT>"
+      Nel:
+      - "<REDACTED_NEL>"
+      Connection:
+      - close
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,PATCH,POST,PUT
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Ratelimit-Limit:
+      - '7000'
+      X-Ratelimit-Remaining:
+      - '6997'
+      X-Ratelimit-Reset:
+      - '1738013436'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1733'
+      Etag:
+      - W/"6c5-fzhN39I+RJs1ywgC2Gpo7+YkiVs"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 27 Jan 2025 21:29:35 GMT
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":56753128,"type":"articles","title":"The Borgs, a New
+        Family of Cdc42 and TC10 GTPase-Interacting Proteins","date":"2023-03-28","authors":"Joberty,
+        Gérard; Perlungher, Richard R.; Macara, Ian G.","inPress":false,"abandoned":false,"doi":"10.1128/MCB.19.10.6585","linkResolverOpenUrl":"https://mit.primo.exlibrisgroup.com/openurl/01MIT_INST/01MIT_INST:LIBKEY?genre=article&aulast=Joberty&issn=0270-7306&title=Molecular%20and%20Cellular%20Biology&atitle=The%20Borgs%2C%20a%20New%20Family%20of%20Cdc42%20and%20TC10%20GTPase-Interacting%20Proteins&volume=19&issue=10&spage=6585&epage=6597&date=2023-03-28&doi=10.1128%2FMCB.19.10.6585&rft_id=info:pmid/10490598&sid=LibKey","pmid":"10490598","openAccess":true,"unpaywallUsable":true,"fullTextFile":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/56753128/full-text-file?utm_source=api_3735","contentLocation":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/56753128/content-location?utm_source=api_3735","availableThroughBrowzine":true,"startPage":"6585","endPage":"6597","browzineWebLink":"https://browzine.com/libraries/FAKE_LIBKEY_ID/journals/18106/issues/7975387?showArticleInContext=doi:10.1128%2FMCB.19.10.6585&utm_source=api_3735","relationships":{"journal":{"data":{"type":"journals","id":18106}}},"bestIntegratorLink":{"bestLink":"https://libkey.io/libraries/FAKE_LIBKEY_ID/articles/56753128/full-text-file?utm_source=api_3735","linkType":"fullTextFile","recommendedLinkText":"Download
+        PDF"}},"included":[{"id":18106,"type":"journals","title":"Molecular and Cellular
+        Biology","issn":"02707306","sjrValue":1.452,"coverImageUrl":"https://assets.thirdiron.com/images/covers/0270-7306.png","browzineEnabled":true,"browzineWebLink":"https://browzine.com/libraries/FAKE_LIBKEY_ID/journals/18106?utm_source=api_3735"}]}'
+  recorded_at: Mon, 27 Jan 2025 21:29:35 GMT
+recorded_with: VCR 6.3.1

--- a/test/vcr_cassettes/libkey_pmid_nonsense.yml
+++ b/test/vcr_cassettes/libkey_pmid_nonsense.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://public-api.thirdiron.com/public/v1/libraries/FAKE_LIBKEY_ID/articles/pmid/nonsense?access_token=FAKE_LIBKEY_KEY&include=journal
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - public-api.thirdiron.com
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Report-To:
+      - "<REDACTED_REPORT_TO>"
+      Reporting-Endpoints:
+      - "<REDACTED_REPORTING_ENDPOINT>"
+      Nel:
+      - "<REDACTED_NEL>"
+      Connection:
+      - close
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,PATCH,POST,PUT
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Ratelimit-Limit:
+      - '7000'
+      X-Ratelimit-Remaining:
+      - '6998'
+      X-Ratelimit-Reset:
+      - '1738347313'
+      Date:
+      - Fri, 31 Jan 2025 18:14:52 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Fri, 31 Jan 2025 18:14:52 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
The PR build has the LibKey ENV all set. If you want to run this locally, grab the 4 values from there. To compare details with the previous doi/pmid lookups I suggest either locally via the ENV or just using staging for the "previous' version.

Separate from this PR will be a decision on whether to default to LibKey. Landing this code does not commit us to using it for both DOI and PMID. That said, I think it is a good option for us or I wouldn't be trying to merge this so keep in mind that I do intend to suggest we convert to this method (at least for staging) very soon.

CodeClimate/rubocop is correct about everything it flagged. I'd like to accept all of that technical debt, but if there is anything you think should be addressed before merge I'm open to it.


Why are these changes being introduced:

* LibKey is a subscription service MITL has just licensed that has some useful additional data we may want to use in building interventions to allow for normalization of features across platforms, such as links to browse journals and direct links to articles without having to construct a link resolver url ourselves

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TCO-134

How does this address that need:

* Creates a class to handle libkey lookups for PMID and DOI
* Adds conditional logic to allow PMID or DOI to independently choose to use LibKey or their defaults

Document any side effects to this change:

* Adds normalization to some other data lookups around author names that were broken that I noticed when adding the new features and felt small enough to roll into this work
* Pubmed IDs now strip the prefix from the indentifer

Summary of changes (please refer to commit messages for full details)

## Developer

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [x] Project documentation has been updated, and yard output previewed
- [ ] No documentation changes are needed

### ENV

- [x] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [ ] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

NO dependencies are updated

NO migrations are included


## Reviewer

### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [ ] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
