### PR TITLE
Restrict ruby and rails upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>MITLibraries/renovate-config:renovate-ruby"
+    "local>MITLibraries/renovate-config:renovate-ruby"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ruby"
+      ],
+      "allowedVersions": "<3.5"
+    },
+    {
+      "matchPackageNames": [
+        "rails"
+      ],
+      "allowedVersions": "<8"
+    }
   ]
 }


### PR DESCRIPTION
Why are these changes being introduced:

* Ruby and Rails should keep versions in line with recommendations
* This pins Ruby to version 3.4.x and Rails to 7.2x
* When we upgrade to Rails 8 we adjust

Summary of changes (please refer to commit messages for full details)