### PR TITLE
Filter searches before citation detector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'climate_control'
+  gem 'mocha'
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
     matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
     multi_json (1.15.0)
     net-http (0.6.0)
@@ -398,6 +400,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -518,6 +521,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mitlibraries-theme!
+  mocha
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect

--- a/app/models/detector/ml_citation.rb
+++ b/app/models/detector/ml_citation.rb
@@ -7,11 +7,15 @@ class Detector
     # For now the initialize method just needs to consult the external lambda.
     #
     #   @param phrase String. Often a `Term.phrase`.
-    #   @return Nothing intentional. Data is written to Hash `@detections` during processing.
+    #   @return Nothing intentional. Data is written to Boolean `@detections` during processing.
     def initialize(phrase)
+      @detections = false
       return unless self.class.expected_env?
 
-      response = fetch(phrase)
+      features = extract_features(phrase)
+      return unless enough_nonzero_values?(features)
+
+      response = fetch(features)
       @detections = response unless response == 'Error'
     end
 
@@ -111,10 +115,10 @@ class Detector
     # define_payload defines the Hash that will be sent to the lambda.
     #
     # @return Hash
-    def define_payload(phrase)
+    def define_payload(features)
       {
         action: 'predict',
-        features: extract_features(phrase),
+        features: features,
         challenge_secret: self.class.lambda_secret
       }
     end
@@ -135,9 +139,9 @@ class Detector
     # error handling with the response.
     #
     # @return Boolean or 'Error'
-    def fetch(phrase)
+    def fetch(features)
       lambda = define_lambda
-      payload = define_payload(phrase)
+      payload = define_payload(features)
 
       response = lambda.post(self.class.lambda_path, payload.to_json)
 
@@ -150,6 +154,14 @@ class Detector
 
         'Error'
       end
+    end
+
+    # Enough_nonzero_values? checks that a provided hash contains at least three values which are not zero.
+    #
+    # @param hash Hash
+    # @return Integer
+    def enough_nonzero_values?(hash)
+      hash.values.count { |v| v != 0 } >= 3
     end
   end
 end

--- a/app/models/detector/ml_citation.rb
+++ b/app/models/detector/ml_citation.rb
@@ -9,8 +9,9 @@ class Detector
     #   @param phrase String. Often a `Term.phrase`.
     #   @return Nothing intentional. Data is written to Boolean `@detections` during processing.
     def initialize(phrase)
-      @detections = false
       return unless self.class.expected_env?
+
+      @detections = false
 
       features = extract_features(phrase)
       return unless enough_nonzero_values?(features)
@@ -157,6 +158,11 @@ class Detector
     end
 
     # Enough_nonzero_values? checks that a provided hash contains at least three values which are not zero.
+    #
+    # @note We chose 3 as our value here after analyzing the behavior of the citation detector across nearly a year of
+    #   search traffic. For searches which had only one or two features that are not zero, we found no actual citations.
+    #   To see the analyses, look at the "Filtering results" and "Surprising predictions" notebooks at
+    #   https://github.com/MITLibraries/tacos-notebooks/tree/main/notebooks/explorations
     #
     # @param hash Hash
     # @return Integer

--- a/test/models/detector/ml_citation_test.rb
+++ b/test/models/detector/ml_citation_test.rb
@@ -77,9 +77,29 @@ class Detector
 
             assert_instance_of Detector::MlCitation, prediction
 
-            assert_nil(prediction.detections)
+            assert_equal(false, prediction.detections)
           end
         end
+      end
+    end
+
+    test 'lookup skips fetching a prediction for search phrases with less than three features' do
+      Detector::MlCitation.any_instance.expects(:fetch).never
+
+      with_enabled_mlcitation do
+        # This search phrase is expected to have only two non-zero feature values, which based on
+        # our analyses will never result in a predicted citation.
+        Detector::MlCitation.new('foobar (2025)')
+      end
+    end
+
+    test 'lookup does not skip fetching a prediction for search phrases with three or more features' do
+      Detector::MlCitation.any_instance.expects(:fetch).once
+
+      with_enabled_mlcitation do
+        # This search phrase is expected to have three non-zero feature values, which is the minimum
+        # number we expect to have any hope of a citation.
+        Detector::MlCitation.new('foobar (2025) 1234-76')
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ SimpleCov.start('rails')
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require 'mocha/minitest'
 
 VCR.configure do |config|
   config.ignore_localhost = false


### PR DESCRIPTION
This moves the extract_features method in Detector::MlCitation into the initialize method, allowing us to quickly check for whether a given term has enough non-zero features to make it worth calling the detector.

From our analysis in the TACOS notebooks, we believe that phrases which result in only two non-zero values among all their features will never end up being a citation - and that this threshold will allow us to skip the citation detector in 90% of searches.

The filtering is performed in a convenience method named enough_nonzero_values? (naming things is hard).

There is one side effect worth noting: the @detections instance variable is now defined as false at the top of the initialize method, before the first guard clause, so that we get a consistent Boolean value in all conditions. This required one test to change that previously expected a nil from the guard clause.

**I have one concern about this approach, but I'd like to talk about it as part of code review:** This approach doesn't seem to leave any traces for us to diagnose after the fact. I thought about whether there should be a data model change here, to indicate which Term records were filtered by this approach, but we haven't talked about that in any detail yet.

Some of the ways that we might use this information would be:
1. To assemble a new batch of training data that has survived the filter;
2. To maintain awareness of how the filter might need to change as we update what features we extract or how the algorithm is trained.

An alternative arrangement to what I'm proposing here would be to have the number of nonzero features calculated in a public method, ideally during feature extraction in `Detector::Citation`. That might allow that value to be returned via GraphQL for training notebooks, or consulted internally without having to recalculate it. The actual filter could still be internal to `Detector::MlCitation`, but `enough_nonzero_features?` would just be an inequality check without the calculation.

## Developer

### Ticket(s)

https://mitlibraries.atlassian.net/browse/TCO-190

### Accessibility

- [ ] ANDI or Wave has been run in accordance to [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened 
      as new issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Documentation

- [ ] Project documentation has been updated, and yard output previewed
- [x] No documentation changes are needed

### ENV

- [ ] All new ENV is documented in README.
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod.
- [x] ENV has not changed.

### Stakeholders

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies and migrations

YES dependencies are updated

NO migrations are included


## Reviewer

### Code

- [x] I have confirmed that the code works as intended.
- [x] Any CodeClimate issues have been fixed or confirmed as
added technical debt.

### Documentation

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message).
- [x] The documentation has been updated or is unnecessary.
- [x] New dependencies are appropriate or there were no changes.

### Testing

- [x] There are appropriate tests covering any new functionality.
- [ ] No additional test coverage is required.
